### PR TITLE
Fix a crash bug on Firefox

### DIFF
--- a/src/plugin1.js
+++ b/src/plugin1.js
@@ -48,7 +48,7 @@ var root = d3hierarchy(data)
       return d.size;
     }
   })
-  .sort(null);
+  .sort();
 
 partition(root);
 


### PR DESCRIPTION
The `sort` method takes either `undefined` or a function.
Passing `null` is not valid.