### PR TITLE
Enable file size reporting for minified bundles. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ plugins: [Visualizer({
 //...
 ```
 
+The file sizes reported are before any minification happens (if UglifyJS is being used, for example).
+Minified module sizes can be calculated using the source maps.
+To enable this mode, pass `{ sourcemap: true }`
+
+```javascript
+var Visualizer = require('rollup-plugin-visualizer');
+
+//...
+plugins: [Visualizer({
+  sourcemap: true
+})],
+//...
+```
 ## Acknowledges
 
 Initially this plugin is based on [webpack-visualizer](http://chrisbateman.github.io/webpack-visualizer/), but at the end rest only styles and layout. Thanks tons of people around internet for great examples of d3 usage.

--- a/plugin.js
+++ b/plugin.js
@@ -140,7 +140,7 @@ function getBytesPerFileUsingSourceMap(rendered) {
 
 // Given a file C:/path/to/file/on/filesystem.js
 // - remove extension
-// - strip filesytstem root
+// - strip filesystem root
 // - return path segments, starting from the tail and working backwards
 // segments('C:/path/to/file/on/filesystem.js') === ['filesystem', 'on', 'file', 'to', 'path']
 function segments(filepath) {


### PR DESCRIPTION
Add a new `{ sourcemap: true }` option to the constructor.

This code uses source maps to calculate the actual size of each bundle.

For each character in the minified file, performs a sourcemap lookup to the original file.  
A running total created for each file.
When all characters have been processed, the running total is applied to each matched module objects.

Maybe 