### PR TITLE
dynamically create directories as per file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "prepare": "npm run build"
   },
   "dependencies": {
+    "mkdirp": "^0.5.1",
     "source-map": "^0.7.2"
   },
   "devDependencies": {

--- a/plugin.js
+++ b/plugin.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const mkdirp = require('mkdirp');
 const SourceMapConsumer = require("source-map").SourceMapConsumer;
 
 const cssString = fs.readFileSync(path.join(__dirname, "lib", "./style.css"), "utf8");
@@ -65,6 +66,7 @@ module.exports = function(opts) {
             ${jsString}
           </script>
       `;
+      mkdirp.sync(path.dirname(filename));
       fs.writeFileSync(filename, html);
     }
   };


### PR DESCRIPTION
This commits allows user to provide any path for file, and will create deeply nested directories and place the file as per the file path .

eg: 
```js
...
  plugins: [
   visualizer({
      filename: './deeply/nested/file/index.html',
      ...
]
...
```