### PR TITLE
Fix source map support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   },
   "dependencies": {
     "mkdirp": "^0.5.1",
-    "source-map": "^0.7.2",
-    "util.promisify": "^1.0.0"
+    "source-map": "^0.7.2"
   },
   "devDependencies": {
     "bytes": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "mkdirp": "^0.5.1",
-    "source-map": "^0.7.2"
+    "source-map": "^0.7.2",
+    "util.promisify": "^1.0.0"
   },
   "devDependencies": {
     "bytes": "^3.0.0",

--- a/plugin.js
+++ b/plugin.js
@@ -189,14 +189,13 @@ function addMinifiedSizesToModules(bundle, rendered) {
     return null;
   };
 
-  return SourceMapConsumer
-    .with(rendered.map, null, map => {
-      const fileSizes = getBytesPerFileUsingSourceMap(rendered.code, map);
-      fileSizes.forEach(tuple => {
-        var module = findBestMatchingModule(tuple.file);
-        if (module) {
-          module.minifiedSize = tuple.bytes;
-        }
-      });
+  return SourceMapConsumer.with(rendered.map, null, map => {
+    const fileSizes = getBytesPerFileUsingSourceMap(rendered.code, map);
+    fileSizes.forEach(tuple => {
+      var module = findBestMatchingModule(tuple.file);
+      if (module) {
+        module.minifiedSize = tuple.bytes;
+      }
     });
+  });
 }

--- a/plugin.js
+++ b/plugin.js
@@ -1,11 +1,11 @@
 const fs = require("fs");
 const path = require("path");
 const mkdirp = require("mkdirp");
-const promisify = require("util.promisify");
+const util = require("util");
 const SourceMapConsumer = require("source-map").SourceMapConsumer;
 
-const writeFileAsync = promisify(fs.writeFile);
-const mkdirpAsync = promisify(mkdirp);
+const writeFileAsync = util.promisify(fs.writeFile);
+const mkdirpAsync = util.promisify(mkdirp);
 
 const cssString = fs.readFileSync(path.join(__dirname, "lib", "./style.css"), "utf8");
 const jsString = fs.readFileSync(path.join(__dirname, "lib", "./pluginmain.js"), "utf8");

--- a/plugin.js
+++ b/plugin.js
@@ -189,9 +189,9 @@ function addMinifiedSizesToModules(bundle, rendered) {
     return null;
   };
 
-  return new SourceMapConsumer(rendered.map)
-    .then(map => getBytesPerFileUsingSourceMap(rendered.code, map))
-    .then(fileSizes => {
+  return SourceMapConsumer
+    .with(rendered.map, null, map => {
+      const fileSizes = getBytesPerFileUsingSourceMap(rendered.code, map);
       fileSizes.forEach(tuple => {
         var module = findBestMatchingModule(tuple.file);
         if (module) {

--- a/plugin.js
+++ b/plugin.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 const path = require("path");
-const mkdirp = require('mkdirp');
+const mkdirp = require("mkdirp");
 const SourceMapConsumer = require("source-map").SourceMapConsumer;
 
 const cssString = fs.readFileSync(path.join(__dirname, "lib", "./style.css"), "utf8");
@@ -90,6 +90,7 @@ function getDeepMoreThenOneChild(tree) {
   }
   return tree;
 }
+
 // if root children have only on child we can flatten this
 function flattenTree(root) {
   var newChildren = [];

--- a/plugin.js
+++ b/plugin.js
@@ -19,17 +19,17 @@ module.exports = function(opts) {
       var bundle = args.bundle;
 
       return Promise.resolve()
-      .then(() => {
-      if (useSourceMap) {
-        return addMinifiedSizesToModules(bundle, rendered);
-      }
-      })
-      .then(() => {
-      var root = buildTree(bundle, useSourceMap);
-      flattenTree(root);
+        .then(() => {
+          if (useSourceMap) {
+            return addMinifiedSizesToModules(bundle, rendered);
+          }
+        })
+        .then(() => {
+          var root = buildTree(bundle, useSourceMap);
+          flattenTree(root);
 
-      writeHtml(title, root, filename);
-      });
+          writeHtml(title, root, filename);
+        });
     }
   };
 };
@@ -181,13 +181,13 @@ function addMinifiedSizesToModules(bundle, rendered) {
   };
 
   return new SourceMapConsumer(rendered.map)
-  .then(map => getBytesPerFileUsingSourceMap(rendered.code, map))
-  .then(fileSizes => {
-  fileSizes.forEach(tuple => {
-    var module = findBestMatchingModule(tuple.file);
-    if (module) {
-      module.minifiedSize = tuple.bytes;
-    }
-  });
-  });
+    .then(map => getBytesPerFileUsingSourceMap(rendered.code, map))
+    .then(fileSizes => {
+      fileSizes.forEach(tuple => {
+        var module = findBestMatchingModule(tuple.file);
+        if (module) {
+          module.minifiedSize = tuple.bytes;
+        }
+      });
+    });
 }

--- a/plugin.js
+++ b/plugin.js
@@ -18,15 +18,23 @@ module.exports = function(opts) {
     ongenerate(args, rendered) {
       var bundle = args.bundle;
 
-      var root = {
-        name: "root",
-        children: []
-      };
-
       if (useSourceMap) {
         addMinifiedSizesToModules(bundle, rendered);
       }
 
+      var root = buildTree(bundle, useSourceMap);
+      flattenTree(root);
+
+      writeHtml(title, root, filename);
+    }
+  };
+};
+
+function buildTree(bundle, useSourceMap) {
+      var root = {
+        name: "root",
+        children: []
+      };
       bundle.modules.forEach(module => {
         var name = module.id;
         var m = {
@@ -41,8 +49,10 @@ module.exports = function(opts) {
           addToPath(root, name.split(path.sep), m);
         }
       });
-      flattenTree(root);
+      return root;
+}
 
+function writeHtml(title, root, filename) {
       var html = `<!doctype html>
           <title>${title}</title>
           <meta charset="utf-8">
@@ -68,9 +78,7 @@ module.exports = function(opts) {
       `;
       mkdirp.sync(path.dirname(filename));
       fs.writeFileSync(filename, html);
-    }
-  };
-};
+}
 
 function getDeepMoreThenOneChild(tree) {
   if (tree.children && tree.children.length === 1) {

--- a/plugin.js
+++ b/plugin.js
@@ -31,53 +31,53 @@ module.exports = function(opts) {
 };
 
 function buildTree(bundle, useSourceMap) {
-      var root = {
-        name: "root",
-        children: []
-      };
-      bundle.modules.forEach(module => {
-        var name = module.id;
-        var m = {
-          //dependencies: module.dependencies,
-          size: useSourceMap ? module.minifiedSize || 0 : Buffer.byteLength(module.code, "utf8"),
-          originalSize: Buffer.byteLength(module.originalCode, "utf8")
-        };
+  var root = {
+    name: "root",
+    children: []
+  };
+  bundle.modules.forEach(module => {
+    var name = module.id;
+    var m = {
+      //dependencies: module.dependencies,
+      size: useSourceMap ? module.minifiedSize || 0 : Buffer.byteLength(module.code, "utf8"),
+      originalSize: Buffer.byteLength(module.originalCode, "utf8")
+    };
 
-        if (name.indexOf(PLUGIN_PREFIX) === 0) {
-          addToPath(root, [name], m);
-        } else {
-          addToPath(root, name.split(path.sep), m);
-        }
-      });
-      return root;
+    if (name.indexOf(PLUGIN_PREFIX) === 0) {
+      addToPath(root, [name], m);
+    } else {
+      addToPath(root, name.split(path.sep), m);
+    }
+  });
+  return root;
 }
 
 function writeHtml(title, root, filename) {
-      var html = `<!doctype html>
-          <title>${title}</title>
-          <meta charset="utf-8">
-          <style>${cssString}</style>
-          <div>
-          <div>
-              <h1>${title}</h1>
+  var html = `<!doctype html>
+      <title>${title}</title>
+      <meta charset="utf-8">
+      <style>${cssString}</style>
+      <div>
+      <div>
+          <h1>${title}</h1>
 
-              <div id="chart">
-                <div class="details" style="display: none;">
-                  <span class="details-name"></span>
-                  <div class="details-percentage"></div>
-                  of bundle size
-                  <div class="details-size"></div>
-                </div>
-              </div>
+          <div id="chart">
+            <div class="details" style="display: none;">
+              <span class="details-name"></span>
+              <div class="details-percentage"></div>
+              of bundle size
+              <div class="details-size"></div>
+            </div>
           </div>
-          </div>
-          <script>window.nodesData = ${JSON.stringify(root)};</script>
-          <script charset="UTF-8">
-            ${jsString}
-          </script>
-      `;
-      mkdirp.sync(path.dirname(filename));
-      fs.writeFileSync(filename, html);
+      </div>
+      </div>
+      <script>window.nodesData = ${JSON.stringify(root)};</script>
+      <script charset="UTF-8">
+        ${jsString}
+      </script>
+  `;
+  mkdirp.sync(path.dirname(filename));
+  fs.writeFileSync(filename, html);
 }
 
 function getDeepMoreThenOneChild(tree) {


### PR DESCRIPTION
The `sourcemap` option is broken since version 0.4.0. Passing `{sourcemap: true}` throws an error:
```
[!] TypeError: map.originalPositionFor is not a function
TypeError: map.originalPositionFor is not a function
    at getBytesPerFileUsingSourceMap (C:\Users\Mattias\Documents\Git\rollup-plugin-visualizer\plugin.js:121:24)
    at addMinifiedSizesToModules (C:\Users\Mattias\Documents\Git\rollup-plugin-visualizer\plugin.js:149:19)
    at Object.ongenerate (C:\Users\Mattias\Documents\Git\rollup-plugin-visualizer\plugin.js:27:9)
    at C:\Users\Mattias\Documents\Git\rollup-plugin-visualizer\node_modules\rollup\dist\rollup.js:21685:40
    at Array.forEach (<anonymous>)
    at C:\Users\Mattias\Documents\Git\rollup-plugin-visualizer\node_modules\rollup\dist\rollup.js:21683:41
    at <anonymous>
```
The cause for this is the recent upgrade to `source-map` version 0.7.2 in be966db3c8c9cac5785b53f5c07621db0d239a04. The `source-map` library [changed their public API in version 0.7.0](https://github.com/mozilla/source-map/blob/0.7.0/CHANGELOG.md) to return a promise, however this plugin was not updated accordingly.

This PR restores source map support by using promises throughout the plugin logic.