### PR TITLE
Fix sourcemap option (again)

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -188,7 +188,7 @@ function addMinifiedSizesToModules(bundle) {
       });
 
       if (matches.length === 1) {
-        return matches[0];
+        return bundle.modules[matches[0]];
       }
     }
 


### PR DESCRIPTION
The `sourcemap` option no longer works in 0.7.0 and 0.8.0. This PR restores its functionality.

For reference, I'm using the following modified `rollup.config-dev.js` to test the `sourcemap` option:
```js
"use strict";

const rollupCommonJs = require("rollup-plugin-commonjs");
const rollupNodeResolve = require("rollup-plugin-node-resolve");
const { terser: rollupTerser } = require("rollup-plugin-terser");
const plugin = require("./plugin");

module.exports = {
  input: "./src/plugin1.js",
  output: { format: "iife", sourcemap: true },
  plugins: [
    rollupNodeResolve({
      jsnext: true,
      main: true,
      module: true
    }),
    rollupCommonJs({
      ignoreGlobal: true,
      include: "node_modules/**"
    }),
    rollupTerser({
      sourceMap: true
    }),
    plugin({
      sourcemap: true
    })
  ]
};
```