### PR TITLE
Specify rollup v0.60+ as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "opn": "^5.3.0",
     "source-map": "^0.7.3"
   },
+  "peerDependencies": {
+    "rollup": ">=0.60.0 <1"
+  },
   "devDependencies": {
     "bytes": "^3.0.0",
     "d3-hierarchy": "^1.1.6",


### PR DESCRIPTION
Using same trick as [rollup-plugin-babel](https://github.com/rollup/rollup-plugin-babel/blob/5168424e7d9e28e612e26c159c39862d8c4727ab/package.json#L38) in order to make sure that correct version of rollup is used (with new hooks instead of old ones https://rollupjs.org/guide/en#deprecated).