### PR TITLE
Fix incorrect WOFF2 media type

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -120,7 +120,7 @@ function buildFontface(name, weight, { woff2, woff }) {
       font-style: normal;
       font-weight: ${weight};
       src:
-        url(data:application/font-woff2;charset=utf-8;base64,${woff2}) format('woff2'),
+        url(data:font/woff2;charset=utf-8;base64,${woff2}) format('woff2'),
         url(data:application/font-woff;charset=utf-8;base64,${woff}) format('woff');
     }`;
 }


### PR DESCRIPTION
Swapping `application/font-woff2` with `font/woff2` per: https://www.w3.org/TR/WOFF2/#IMT