### PR TITLE
Relax the node constraint to be >=8.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "rollup-plugin-uglify": "^6.0.2"
   },
   "engines": {
-    "node": ">=8.9"
+    "node": ">=8.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "rollup-plugin-uglify": "^6.0.2"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=8.9"
   }
 }


### PR DESCRIPTION
There are still many users using node 8 since it is LTS and its end of life is scheduled on December 31, 2019.

The node 10 constraint limits us (https://github.com/tensorflow/tfjs) to use the library since we want to work in node >=8.

I tested this visualization library with 8.10.0 and it works great, thus relaxing the node constraint.