### PR TITLE
Include build-html.js file in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "files": [
     "lib/*",
+    "build-html.js",
     "plugin.js"
   ],
   "repository": {


### PR DESCRIPTION
Hey there, I happened to come across your plugin today (looks like just after a new build released). Looks like the build-html file was just left out of the published package. :clinking_glasses: 