### PR TITLE
add styleOverridePath option to inject user defined css styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ plugins: [
 
 `template` (string, default `sunburst`) - Which digram type to use: `sunburst`, `treemap`, `circlepacking`, `network` (very early stage, feedback welcomed)
 
+`styleOverridePath` (string, default `undefined`) - Link your own css file to override or enhance the current templates
+
 `bundlesRelative` (boolean, default `false`) - Combine all bundles to one diagram
 
 ## Build plugin

--- a/plugin/build-stats.js
+++ b/plugin/build-stats.js
@@ -5,17 +5,19 @@ const path = require("path");
 const pupa = require("pupa");
 const readFile = require("util").promisify(fs.readFile);
 
-module.exports = async function buildHtml(title, nodesData, graphType) {
-  const [template, script, style] = await Promise.all([
+module.exports = async function buildHtml(title, nodesData, graphType, styleOverridePath) {
+  const [template, script, style, styleOverride] = await Promise.all([
     readFile(path.join(__dirname, "stats.template"), "utf-8"),
     readFile(path.join(__dirname, "..", "lib", `main-${graphType}.js`), "utf8"),
-    readFile(path.join(__dirname, "..", "lib", `style-${graphType}.css`), "utf8")
+    readFile(path.join(__dirname, "..", "lib", `style-${graphType}.css`), "utf8"),
+    styleOverridePath ? readFile(styleOverridePath, "utf8") : Promise.resolve()
   ]);
 
   return pupa(template, {
     title,
     style,
     script,
+    styleOverride,
     nodesData: JSON.stringify(nodesData)
   });
 };

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -40,6 +40,7 @@ module.exports = function(opts) {
   const openOptions = opts.openOptions || {};
 
   const template = opts.template || "sunburst";
+  const styleOverridePath = opts.styleOverridePath;
 
   const bundlesRelative = !!opts.bundlesRelative;
 
@@ -112,7 +113,7 @@ module.exports = function(opts) {
         roots = [roots];
       }
 
-      const html = await buildStats(title, roots, template);
+      const html = await buildStats(title, roots, template, styleOverridePath);
 
       await mkdir(path.dirname(filename));
       await writeFile(filename, html);

--- a/plugin/stats.template
+++ b/plugin/stats.template
@@ -6,6 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>{{title}}</title>
   <style>{style}</style>
+  <style>{styleOverride}</style>
 </head>
 <body>
   <h1>{{title}}</h1>


### PR DESCRIPTION
Here's a really simple PR to extend the plugins styling options - so that people can supply their own.

Relates to #44 

Note: I'm not overly happy about not being able to conditionally inject content based on template variables. e.g. if you don't provide a `styleOverridePath` the document outputs an empty style tag `<style></style>`. Thought it might be better to leave it like this rather than declare the tag in javascript.

Let me know what you think. Thanks