### PR TITLE
Match stats path with bundle output path

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -32,7 +32,6 @@ const isAsset = (bundle) =>
 module.exports = function (opts) {
   opts = opts || {};
   const json = !!opts.json;
-  const filename = opts.filename || (json ? "stats.json" : "stats.html");
   const title = opts.title || "RollUp Visualizer";
 
   const open = !!opts.open;
@@ -84,6 +83,8 @@ module.exports = function (opts) {
       const roots = [];
       const mapper = new ModuleMapper();
       const links = [];
+      const filename = opts.filename ||
+        path.join(outputOptions.dir || "", `${outputOptions.file}.stats.${json ? "json" : "html"}`)
 
       // collect trees
       for (const [id, bundle] of Object.entries(outputBundle)) {


### PR DESCRIPTION
This is a spike implementation of #75 

It has been working locally in my manually-edited node_modules.

The visualizer plugin is still added to the top-level `plugins` array (it is _not_ used as an output plugin). But it allows the visualizer plugin to be added without any configuration and to be used with multiple output bundles:

```
{
  plugins: [ visualizer() ],
  input: "foo",
  output: [
    { format: 'es', file: 'foo1.js' },
    { format: 'es', file: 'foo2.js' }
}
```

This configuration generates:
- foo1.js.stats.html
- foo2.js.stats.html

(not expecting this PR to be merged as-is. It's just a proof-of concept that I've been using myself)