### PR TITLE
Null Check: DynamicallyImportedIds not present

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-visualizer",
-  "version": "5.5.1",
+  "version": "5.5.0",
   "main": "./dist/plugin/index.js",
   "author": "Denis Bardadym <bardadymchik@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-visualizer",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "main": "./dist/plugin/index.js",
   "author": "Denis Bardadym <bardadymchik@gmail.com>",
   "license": "MIT",

--- a/plugin/data.ts
+++ b/plugin/data.ts
@@ -128,7 +128,7 @@ export const addLinks = (startModuleId: string, getModuleInfo: GetModuleInfo, ma
 
       moduleIds.push(importedId);
     }
-    for (const importedId of moduleInfo.dynamicallyImportedIds) {
+    for (const importedId of moduleInfo.dynamicallyImportedIds || []) {
       mapper.addImportedByLink(importedId, moduleId);
       mapper.addImportedLink(moduleId, importedId, true);
 


### PR DESCRIPTION
Our project didn't had any Dynamic Imports, causing this error.

Error: Failed to bundle the javascript package:
moduleInfo.dynamicallyImportedIds is not iterable
{
  "code": "PLUGIN_ERROR",
  "plugin": "visualizer",
  "hook": "generateBundle"
}