### PR TITLE
Update SvelteKit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,22 +51,16 @@ module.exports = {
 };
 ```
 
-Usage with SvelteKit (svelte.config.js)
+Usage with SvelteKit (vite.config.js)
 
 ```js
-import path from "path";
-
 const config = {
-  kit: {
-    vite: {
-      plugins: [
-        visualizer({
-          emitFile: true,
-          file: 'stats.html'
-        })
-      ]
-    }
-  },
+  plugins: [
+    visualizer({
+      emitFile: true,
+      file: 'stats.html'
+    })
+  ],
 };
 
 export default config;


### PR DESCRIPTION
Hi 👋

Since [@sveltejs/kit@1.0.0-next.359](https://github.com/sveltejs/kit/releases/tag/%40sveltejs%2Fkit%401.0.0-next.359) the plugin configuration moved to `vite.config.[tj]s` so I updated the docs to reflect this change.