### PR TITLE
fix: typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const config = {
   plugins: [
     visualizer({
       emitFile: true,
-      file: "stats.html",
+      filename: "stats.html",
     }),
   ],
 };


### PR DESCRIPTION
Reading the [options](https://github.com/stenehall/rollup-plugin-visualizer#options) it should be `filename`. The type definition is also complaining about `file`.