### PR TITLE
Fix: use minified size in sourcemap mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Output yml file with all the data, could be good idea to commit this file to tra
 
 `open` (boolean, default `false`) - Open generated file in default user agent
 
+`sourcemap` (boolean, default `false`) - Use sourcemap to calculate module sizes. Gives more precise results by accounting for code transformation and minification. Sourcemap generation [must be enabled in rollup options.](https://rollupjs.org/configuration-options/#output-sourcemap)
+
 `template` (string, default `treemap`) - Which diagram type to use: `sunburst`, `treemap`, `network`, `raw-data`, `list`.
 
 `gzipSize` (boolean, default `false`) - Collect gzip size from source code and display it at chart.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "rollup-plugin-visualizer",
-      "version": "5.8.3",
+      "version": "5.9.0",
       "license": "MIT",
       "dependencies": {
         "open": "^8.4.0",
@@ -22,6 +22,7 @@
         "@rollup/plugin-alias": "^4.0.2",
         "@rollup/plugin-commonjs": "^24.0.0",
         "@rollup/plugin-node-resolve": "^15.0.0",
+        "@rollup/plugin-terser": "^0.4.2",
         "@rollup/plugin-typescript": "^10.0.1",
         "@types/bytes": "^3.1.1",
         "@types/d3-array": "^3.0.3",
@@ -1221,6 +1222,30 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
@@ -1335,6 +1360,28 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-terser": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.2.tgz",
+      "integrity": "sha512-jfUVQ4MxzIB0mz8QhDA1xiLT+pTF3WEWXeIqcwhoF84WhLWscPpxjJgjYMyAq0Po4UXqw2D9C64tD0gRDzJzfA==",
+      "dev": true,
+      "dependencies": {
+        "serialize-javascript": "^6.0.0",
+        "smob": "^0.0.6",
+        "terser": "^5.15.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.x || ^3.x"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -7037,6 +7084,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -7402,6 +7458,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/safe-identifier": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
@@ -7472,6 +7548,15 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7539,6 +7624,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/smob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+      "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==",
+      "dev": true
     },
     "node_modules/source-map": {
       "version": "0.7.4",
@@ -7840,6 +7931,49 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.17.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.4.tgz",
+      "integrity": "sha512-jcEKZw6UPrgugz/0Tuk/PVyLAPfMBJf5clnGueo45wTweoV8yh7Q7PEkhkJ5uuUbC7zAxEcG3tqNr1bstkQ8nw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/terser/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/terser/node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/test-exclude": {
@@ -9174,6 +9308,29 @@
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true
     },
+    "@jridgewell/source-map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.3.tgz",
+      "integrity": "sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+          "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
+      }
+    },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
@@ -9251,6 +9408,17 @@
         "is-builtin-module": "^3.2.0",
         "is-module": "^1.0.0",
         "resolve": "^1.22.1"
+      }
+    },
+    "@rollup/plugin-terser": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.2.tgz",
+      "integrity": "sha512-jfUVQ4MxzIB0mz8QhDA1xiLT+pTF3WEWXeIqcwhoF84WhLWscPpxjJgjYMyAq0Po4UXqw2D9C64tD0gRDzJzfA==",
+      "dev": true,
+      "requires": {
+        "serialize-javascript": "^6.0.0",
+        "smob": "^0.0.6",
+        "terser": "^5.15.1"
       }
     },
     "@rollup/plugin-typescript": {
@@ -13339,6 +13507,15 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -13598,6 +13775,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
     "safe-identifier": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
@@ -13652,6 +13835,15 @@
         }
       }
     },
+    "serialize-javascript": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
+      "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -13700,6 +13892,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
       "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true
+    },
+    "smob": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/smob/-/smob-0.0.6.tgz",
+      "integrity": "sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==",
       "dev": true
     },
     "source-map": {
@@ -13930,6 +14128,42 @@
         "csso": "^4.2.0",
         "picocolors": "^1.0.0",
         "stable": "^0.1.8"
+      }
+    },
+    "terser": {
+      "version": "5.17.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.4.tgz",
+      "integrity": "sha512-jcEKZw6UPrgugz/0Tuk/PVyLAPfMBJf5clnGueo45wTweoV8yh7Q7PEkhkJ5uuUbC7zAxEcG3tqNr1bstkQ8nw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.21",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+          "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
       }
     },
     "test-exclude": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@rollup/plugin-alias": "^4.0.2",
     "@rollup/plugin-commonjs": "^24.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
+    "@rollup/plugin-terser": "^0.4.2",
     "@rollup/plugin-typescript": "^10.0.1",
     "@types/bytes": "^3.1.1",
     "@types/d3-array": "^3.0.3",

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -156,8 +156,8 @@ export const visualizer = (
 
       const filter = createFilter(opts.include, opts.exclude);
 
-      const gzipSize = !!opts.gzipSize && !opts.sourcemap;
-      const brotliSize = !!opts.brotliSize && !opts.sourcemap;
+      const gzipSize = !!opts.gzipSize;
+      const brotliSize = !!opts.brotliSize;
       const gzipSizeGetter = gzipSize
         ? createGzipSizeGetter(typeof opts.gzipSize === "object" ? opts.gzipSize : {})
         : defaultSizeGetter;

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -83,7 +83,6 @@ export interface PluginVisualizerOptions {
 
   /**
    * If plugin should use sourcemap to calculate sizes of modules. By idea it will present more accurate results.
-   * `gzipSize` and `brotliSize` does not make much sense with this option.
    *
    * @default false
    */

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -167,12 +167,10 @@ export const visualizer = (
 
       const ModuleLengths = async ({
         id,
-        renderedLength,
         code,
       }: {
         id: string;
-        renderedLength: number;
-        code: string | null;
+        code: string;
       }): Promise<ModuleLengths & { id: string }> => {
         const isCodeEmpty = code == null || code == "";
 
@@ -180,7 +178,7 @@ export const visualizer = (
           id,
           gzipLength: isCodeEmpty ? 0 : await gzipSizeGetter(code),
           brotliLength: isCodeEmpty ? 0 : await brotliSizeGetter(code),
-          renderedLength: isCodeEmpty ? renderedLength : Buffer.byteLength(code, "utf-8"),
+          renderedLength: isCodeEmpty ? 0 : Buffer.byteLength(code, "utf-8"),
         };
         return result;
       };
@@ -214,9 +212,8 @@ export const visualizer = (
           const moduleRenderInfo = await Promise.all(
             Object.values(modules)
               .filter(({ id }) => filter(bundleId, id))
-              .map(({ id, renderedLength }) => {
-                const code = bundle.modules[id]?.code;
-                return ModuleLengths({ id, renderedLength, code });
+              .map(({ id, code }) => {
+                return ModuleLengths({ id, code });
               })
           );
 
@@ -225,7 +222,7 @@ export const visualizer = (
           const modules = await Promise.all(
             Object.entries(bundle.modules)
               .filter(([id]) => filter(bundleId, id))
-              .map(([id, { renderedLength, code }]) => ModuleLengths({ id, renderedLength, code }))
+              .map(([id, { code }]) => ModuleLengths({ id, code: code || "" }))
           );
 
           tree = buildTree(bundleId, modules, mapper);
@@ -234,7 +231,6 @@ export const visualizer = (
         if (tree.children.length === 0) {
           const bundleSizes = await ModuleLengths({
             id: bundleId,
-            renderedLength: bundle.code.length,
             code: bundle.code,
           });
 

--- a/plugin/sourcemap.ts
+++ b/plugin/sourcemap.ts
@@ -4,7 +4,7 @@ import { SourceMapConsumer } from "source-map";
 
 interface SourceMapModuleRenderInfo {
   id: string;
-  renderedLength: number;
+  code: string;
 }
 
 const getBytesPerFileUsingSourceMap = (
@@ -25,8 +25,8 @@ const getBytesPerFileUsingSourceMap = (
     if (source != null) {
       const id = path.resolve(path.dirname(path.join(dir, bundleId)), source);
 
-      modules[id] = modules[id] || { id, renderedLength: 0 };
-      modules[id].renderedLength += 1;
+      modules[id] = modules[id] || { id, code: "" };
+      modules[id].code += code[i];
     }
 
     if (code[i] === "\n") {

--- a/test/__snapshots__/e2e.test.ts.snap
+++ b/test/__snapshots__/e2e.test.ts.snap
@@ -1,5 +1,137 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`E2E sourcemap + terser test 1`] = `
+"{
+  "version": 2,
+  "tree": {
+    "name": "root",
+    "children": [
+      {
+        "name": "input.js",
+        "children": [
+          {
+            "name": "test/e2e/input.js",
+            "uid": "1111-81"
+          }
+        ]
+      },
+      {
+        "name": "input2.js",
+        "children": [
+          {
+            "name": "test/e2e/input2.js",
+            "uid": "1111-83"
+          }
+        ]
+      },
+      {
+        "name": "file3-fd37dfe7.js",
+        "children": [
+          {
+            "name": "test/e2e/file3.js",
+            "uid": "1111-85"
+          }
+        ]
+      }
+    ],
+    "isRoot": true
+  },
+  "nodeParts": {
+    "1111-81": {
+      "renderedLength": 66,
+      "gzipLength": 0,
+      "brotliLength": 0,
+      "metaUid": "1111-80"
+    },
+    "1111-83": {
+      "renderedLength": 80,
+      "gzipLength": 0,
+      "brotliLength": 0,
+      "metaUid": "1111-82"
+    },
+    "1111-85": {
+      "renderedLength": 18,
+      "gzipLength": 0,
+      "brotliLength": 0,
+      "metaUid": "1111-84"
+    }
+  },
+  "nodeMetas": {
+    "1111-80": {
+      "id": "/test/e2e/input.js",
+      "moduleParts": {
+        "input.js": "1111-81"
+      },
+      "imported": [
+        {
+          "uid": "1111-86"
+        },
+        {
+          "uid": "1111-87"
+        }
+      ],
+      "importedBy": [],
+      "isEntry": true
+    },
+    "1111-82": {
+      "id": "/test/e2e/input2.js",
+      "moduleParts": {
+        "input2.js": "1111-83"
+      },
+      "imported": [
+        {
+          "uid": "1111-84",
+          "dynamic": true
+        }
+      ],
+      "importedBy": [],
+      "isEntry": true
+    },
+    "1111-84": {
+      "id": "/test/e2e/file3.js",
+      "moduleParts": {
+        "file3-fd37dfe7.js": "1111-85"
+      },
+      "imported": [],
+      "importedBy": [
+        {
+          "uid": "1111-82"
+        }
+      ]
+    },
+    "1111-86": {
+      "id": "/test/e2e/node_modules/module/test.js",
+      "moduleParts": {},
+      "imported": [],
+      "importedBy": [
+        {
+          "uid": "1111-80"
+        }
+      ]
+    },
+    "1111-87": {
+      "id": "jquery",
+      "moduleParts": {},
+      "imported": [],
+      "importedBy": [
+        {
+          "uid": "1111-80"
+        }
+      ],
+      "isExternal": true
+    }
+  },
+  "env": {
+    "rollup": "3.9.0"
+  },
+  "options": {
+    "gzip": false,
+    "brotli": false,
+    "sourcemap": true
+  }
+}"
+`;
+
 exports[`E2E sourcemap test - "list" 1`] = `
 "file3-6fe2c43f.js:
   /test/e2e/file3.js:

--- a/test/__snapshots__/e2e.test.ts.snap
+++ b/test/__snapshots__/e2e.test.ts.snap
@@ -38,19 +38,19 @@ exports[`E2E sourcemap + terser test 1`] = `
   },
   "nodeParts": {
     "1111-81": {
-      "renderedLength": 66,
+      "renderedLength": 22,
       "gzipLength": 0,
       "brotliLength": 0,
       "metaUid": "1111-80"
     },
     "1111-83": {
-      "renderedLength": 80,
+      "renderedLength": 57,
       "gzipLength": 0,
       "brotliLength": 0,
       "metaUid": "1111-82"
     },
     "1111-85": {
-      "renderedLength": 18,
+      "renderedLength": 32,
       "gzipLength": 0,
       "brotliLength": 0,
       "metaUid": "1111-84"
@@ -135,13 +135,13 @@ exports[`E2E sourcemap + terser test 1`] = `
 exports[`E2E sourcemap test - "list" 1`] = `
 "file3-6fe2c43f.js:
   /test/e2e/file3.js:
-    rendered: 18
+    rendered: 19
 input.js:
   /test/e2e/input.js:
-    rendered: 66
+    rendered: 67
 input2.js:
   /test/e2e/input2.js:
-    rendered: 80
+    rendered: 81
 "
 `;
 
@@ -6766,7 +6766,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"input.js","children":[{"name":"test/e2e/input.js","uid":"1111-57"}]},{"name":"input2.js","children":[{"name":"test/e2e/input2.js","uid":"1111-59"}]},{"name":"file3-6fe2c43f.js","children":[{"name":"test/e2e/file3.js","uid":"1111-61"}]}],"isRoot":true},"nodeParts":{"1111-57":{"renderedLength":66,"gzipLength":0,"brotliLength":0,"metaUid":"1111-56"},"1111-59":{"renderedLength":80,"gzipLength":0,"brotliLength":0,"metaUid":"1111-58"},"1111-61":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"1111-60"}},"nodeMetas":{"1111-56":{"id":"/test/e2e/input.js","moduleParts":{"input.js":"1111-57"},"imported":[{"uid":"1111-62"},{"uid":"1111-63"}],"importedBy":[],"isEntry":true},"1111-58":{"id":"/test/e2e/input2.js","moduleParts":{"input2.js":"1111-59"},"imported":[{"uid":"1111-60","dynamic":true}],"importedBy":[],"isEntry":true},"1111-60":{"id":"/test/e2e/file3.js","moduleParts":{"file3-6fe2c43f.js":"1111-61"},"imported":[],"importedBy":[{"uid":"1111-58"}]},"1111-62":{"id":"/test/e2e/node_modules/module/test.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-56"}]},"1111-63":{"id":"jquery","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-56"}],"isExternal":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"input.js","children":[{"name":"test/e2e/input.js","uid":"1111-57"}]},{"name":"input2.js","children":[{"name":"test/e2e/input2.js","uid":"1111-59"}]},{"name":"file3-6fe2c43f.js","children":[{"name":"test/e2e/file3.js","uid":"1111-61"}]}],"isRoot":true},"nodeParts":{"1111-57":{"renderedLength":67,"gzipLength":0,"brotliLength":0,"metaUid":"1111-56"},"1111-59":{"renderedLength":81,"gzipLength":0,"brotliLength":0,"metaUid":"1111-58"},"1111-61":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"1111-60"}},"nodeMetas":{"1111-56":{"id":"/test/e2e/input.js","moduleParts":{"input.js":"1111-57"},"imported":[{"uid":"1111-62"},{"uid":"1111-63"}],"importedBy":[],"isEntry":true},"1111-58":{"id":"/test/e2e/input2.js","moduleParts":{"input2.js":"1111-59"},"imported":[{"uid":"1111-60","dynamic":true}],"importedBy":[],"isEntry":true},"1111-60":{"id":"/test/e2e/file3.js","moduleParts":{"file3-6fe2c43f.js":"1111-61"},"imported":[],"importedBy":[{"uid":"1111-58"}]},"1111-62":{"id":"/test/e2e/node_modules/module/test.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-56"}]},"1111-63":{"id":"jquery","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-56"}],"isExternal":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -6825,19 +6825,19 @@ exports[`E2E sourcemap test - "raw-data" 1`] = `
   },
   "nodeParts": {
     "1111-65": {
-      "renderedLength": 66,
+      "renderedLength": 67,
       "gzipLength": 0,
       "brotliLength": 0,
       "metaUid": "1111-64"
     },
     "1111-67": {
-      "renderedLength": 80,
+      "renderedLength": 81,
       "gzipLength": 0,
       "brotliLength": 0,
       "metaUid": "1111-66"
     },
     "1111-69": {
-      "renderedLength": 18,
+      "renderedLength": 19,
       "gzipLength": 0,
       "brotliLength": 0,
       "metaUid": "1111-68"
@@ -13813,7 +13813,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"input.js","children":[{"name":"test/e2e/input.js","uid":"1111-49"}]},{"name":"input2.js","children":[{"name":"test/e2e/input2.js","uid":"1111-51"}]},{"name":"file3-6fe2c43f.js","children":[{"name":"test/e2e/file3.js","uid":"1111-53"}]}],"isRoot":true},"nodeParts":{"1111-49":{"renderedLength":66,"gzipLength":0,"brotliLength":0,"metaUid":"1111-48"},"1111-51":{"renderedLength":80,"gzipLength":0,"brotliLength":0,"metaUid":"1111-50"},"1111-53":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"1111-52"}},"nodeMetas":{"1111-48":{"id":"/test/e2e/input.js","moduleParts":{"input.js":"1111-49"},"imported":[{"uid":"1111-54"},{"uid":"1111-55"}],"importedBy":[],"isEntry":true},"1111-50":{"id":"/test/e2e/input2.js","moduleParts":{"input2.js":"1111-51"},"imported":[{"uid":"1111-52","dynamic":true}],"importedBy":[],"isEntry":true},"1111-52":{"id":"/test/e2e/file3.js","moduleParts":{"file3-6fe2c43f.js":"1111-53"},"imported":[],"importedBy":[{"uid":"1111-50"}]},"1111-54":{"id":"/test/e2e/node_modules/module/test.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-48"}]},"1111-55":{"id":"jquery","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-48"}],"isExternal":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"input.js","children":[{"name":"test/e2e/input.js","uid":"1111-49"}]},{"name":"input2.js","children":[{"name":"test/e2e/input2.js","uid":"1111-51"}]},{"name":"file3-6fe2c43f.js","children":[{"name":"test/e2e/file3.js","uid":"1111-53"}]}],"isRoot":true},"nodeParts":{"1111-49":{"renderedLength":67,"gzipLength":0,"brotliLength":0,"metaUid":"1111-48"},"1111-51":{"renderedLength":81,"gzipLength":0,"brotliLength":0,"metaUid":"1111-50"},"1111-53":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"1111-52"}},"nodeMetas":{"1111-48":{"id":"/test/e2e/input.js","moduleParts":{"input.js":"1111-49"},"imported":[{"uid":"1111-54"},{"uid":"1111-55"}],"importedBy":[],"isEntry":true},"1111-50":{"id":"/test/e2e/input2.js","moduleParts":{"input2.js":"1111-51"},"imported":[{"uid":"1111-52","dynamic":true}],"importedBy":[],"isEntry":true},"1111-52":{"id":"/test/e2e/file3.js","moduleParts":{"file3-6fe2c43f.js":"1111-53"},"imported":[],"importedBy":[{"uid":"1111-50"}]},"1111-54":{"id":"/test/e2e/node_modules/module/test.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-48"}]},"1111-55":{"id":"jquery","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-48"}],"isExternal":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -19994,7 +19994,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"input.js","children":[{"name":"test/e2e/input.js","uid":"1111-41"}]},{"name":"input2.js","children":[{"name":"test/e2e/input2.js","uid":"1111-43"}]},{"name":"file3-6fe2c43f.js","children":[{"name":"test/e2e/file3.js","uid":"1111-45"}]}],"isRoot":true},"nodeParts":{"1111-41":{"renderedLength":66,"gzipLength":0,"brotliLength":0,"metaUid":"1111-40"},"1111-43":{"renderedLength":80,"gzipLength":0,"brotliLength":0,"metaUid":"1111-42"},"1111-45":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"1111-44"}},"nodeMetas":{"1111-40":{"id":"/test/e2e/input.js","moduleParts":{"input.js":"1111-41"},"imported":[{"uid":"1111-46"},{"uid":"1111-47"}],"importedBy":[],"isEntry":true},"1111-42":{"id":"/test/e2e/input2.js","moduleParts":{"input2.js":"1111-43"},"imported":[{"uid":"1111-44","dynamic":true}],"importedBy":[],"isEntry":true},"1111-44":{"id":"/test/e2e/file3.js","moduleParts":{"file3-6fe2c43f.js":"1111-45"},"imported":[],"importedBy":[{"uid":"1111-42"}]},"1111-46":{"id":"/test/e2e/node_modules/module/test.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-40"}]},"1111-47":{"id":"jquery","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-40"}],"isExternal":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"input.js","children":[{"name":"test/e2e/input.js","uid":"1111-41"}]},{"name":"input2.js","children":[{"name":"test/e2e/input2.js","uid":"1111-43"}]},{"name":"file3-6fe2c43f.js","children":[{"name":"test/e2e/file3.js","uid":"1111-45"}]}],"isRoot":true},"nodeParts":{"1111-41":{"renderedLength":67,"gzipLength":0,"brotliLength":0,"metaUid":"1111-40"},"1111-43":{"renderedLength":81,"gzipLength":0,"brotliLength":0,"metaUid":"1111-42"},"1111-45":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"1111-44"}},"nodeMetas":{"1111-40":{"id":"/test/e2e/input.js","moduleParts":{"input.js":"1111-41"},"imported":[{"uid":"1111-46"},{"uid":"1111-47"}],"importedBy":[],"isEntry":true},"1111-42":{"id":"/test/e2e/input2.js","moduleParts":{"input2.js":"1111-43"},"imported":[{"uid":"1111-44","dynamic":true}],"importedBy":[],"isEntry":true},"1111-44":{"id":"/test/e2e/file3.js","moduleParts":{"file3-6fe2c43f.js":"1111-45"},"imported":[],"importedBy":[{"uid":"1111-42"}]},"1111-46":{"id":"/test/e2e/node_modules/module/test.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-40"}]},"1111-47":{"id":"jquery","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-40"}],"isExternal":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;

--- a/test/__snapshots__/e2e.test.ts.snap
+++ b/test/__snapshots__/e2e.test.ts.snap
@@ -39,20 +39,20 @@ exports[`E2E sourcemap + terser test 1`] = `
   "nodeParts": {
     "1111-81": {
       "renderedLength": 22,
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 42,
+      "brotliLength": 26,
       "metaUid": "1111-80"
     },
     "1111-83": {
       "renderedLength": 57,
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 77,
+      "brotliLength": 61,
       "metaUid": "1111-82"
     },
     "1111-85": {
       "renderedLength": 32,
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 52,
+      "brotliLength": 36,
       "metaUid": "1111-84"
     }
   },
@@ -125,8 +125,8 @@ exports[`E2E sourcemap + terser test 1`] = `
     "rollup": "3.9.0"
   },
   "options": {
-    "gzip": false,
-    "brotli": false,
+    "gzip": true,
+    "brotli": true,
     "sourcemap": true
   }
 }"
@@ -136,12 +136,18 @@ exports[`E2E sourcemap test - "list" 1`] = `
 "file3-6fe2c43f.js:
   /test/e2e/file3.js:
     rendered: 19
+    gzip: 39
+    brotli: 23
 input.js:
   /test/e2e/input.js:
     rendered: 67
+    gzip: 80
+    brotli: 68
 input2.js:
   /test/e2e/input2.js:
     rendered: 81
+    gzip: 95
+    brotli: 82
 "
 `;
 
@@ -6766,7 +6772,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"input.js","children":[{"name":"test/e2e/input.js","uid":"1111-57"}]},{"name":"input2.js","children":[{"name":"test/e2e/input2.js","uid":"1111-59"}]},{"name":"file3-6fe2c43f.js","children":[{"name":"test/e2e/file3.js","uid":"1111-61"}]}],"isRoot":true},"nodeParts":{"1111-57":{"renderedLength":67,"gzipLength":0,"brotliLength":0,"metaUid":"1111-56"},"1111-59":{"renderedLength":81,"gzipLength":0,"brotliLength":0,"metaUid":"1111-58"},"1111-61":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"1111-60"}},"nodeMetas":{"1111-56":{"id":"/test/e2e/input.js","moduleParts":{"input.js":"1111-57"},"imported":[{"uid":"1111-62"},{"uid":"1111-63"}],"importedBy":[],"isEntry":true},"1111-58":{"id":"/test/e2e/input2.js","moduleParts":{"input2.js":"1111-59"},"imported":[{"uid":"1111-60","dynamic":true}],"importedBy":[],"isEntry":true},"1111-60":{"id":"/test/e2e/file3.js","moduleParts":{"file3-6fe2c43f.js":"1111-61"},"imported":[],"importedBy":[{"uid":"1111-58"}]},"1111-62":{"id":"/test/e2e/node_modules/module/test.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-56"}]},"1111-63":{"id":"jquery","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-56"}],"isExternal":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"input.js","children":[{"name":"test/e2e/input.js","uid":"1111-57"}]},{"name":"input2.js","children":[{"name":"test/e2e/input2.js","uid":"1111-59"}]},{"name":"file3-6fe2c43f.js","children":[{"name":"test/e2e/file3.js","uid":"1111-61"}]}],"isRoot":true},"nodeParts":{"1111-57":{"renderedLength":67,"gzipLength":80,"brotliLength":68,"metaUid":"1111-56"},"1111-59":{"renderedLength":81,"gzipLength":95,"brotliLength":82,"metaUid":"1111-58"},"1111-61":{"renderedLength":19,"gzipLength":39,"brotliLength":23,"metaUid":"1111-60"}},"nodeMetas":{"1111-56":{"id":"/test/e2e/input.js","moduleParts":{"input.js":"1111-57"},"imported":[{"uid":"1111-62"},{"uid":"1111-63"}],"importedBy":[],"isEntry":true},"1111-58":{"id":"/test/e2e/input2.js","moduleParts":{"input2.js":"1111-59"},"imported":[{"uid":"1111-60","dynamic":true}],"importedBy":[],"isEntry":true},"1111-60":{"id":"/test/e2e/file3.js","moduleParts":{"file3-6fe2c43f.js":"1111-61"},"imported":[],"importedBy":[{"uid":"1111-58"}]},"1111-62":{"id":"/test/e2e/node_modules/module/test.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-56"}]},"1111-63":{"id":"jquery","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-56"}],"isExternal":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":true,"brotli":true,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -6826,20 +6832,20 @@ exports[`E2E sourcemap test - "raw-data" 1`] = `
   "nodeParts": {
     "1111-65": {
       "renderedLength": 67,
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 80,
+      "brotliLength": 68,
       "metaUid": "1111-64"
     },
     "1111-67": {
       "renderedLength": 81,
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 95,
+      "brotliLength": 82,
       "metaUid": "1111-66"
     },
     "1111-69": {
       "renderedLength": 19,
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 39,
+      "brotliLength": 23,
       "metaUid": "1111-68"
     }
   },
@@ -6912,8 +6918,8 @@ exports[`E2E sourcemap test - "raw-data" 1`] = `
     "rollup": "3.9.0"
   },
   "options": {
-    "gzip": false,
-    "brotli": false,
+    "gzip": true,
+    "brotli": true,
     "sourcemap": true
   }
 }"
@@ -13813,7 +13819,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"input.js","children":[{"name":"test/e2e/input.js","uid":"1111-49"}]},{"name":"input2.js","children":[{"name":"test/e2e/input2.js","uid":"1111-51"}]},{"name":"file3-6fe2c43f.js","children":[{"name":"test/e2e/file3.js","uid":"1111-53"}]}],"isRoot":true},"nodeParts":{"1111-49":{"renderedLength":67,"gzipLength":0,"brotliLength":0,"metaUid":"1111-48"},"1111-51":{"renderedLength":81,"gzipLength":0,"brotliLength":0,"metaUid":"1111-50"},"1111-53":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"1111-52"}},"nodeMetas":{"1111-48":{"id":"/test/e2e/input.js","moduleParts":{"input.js":"1111-49"},"imported":[{"uid":"1111-54"},{"uid":"1111-55"}],"importedBy":[],"isEntry":true},"1111-50":{"id":"/test/e2e/input2.js","moduleParts":{"input2.js":"1111-51"},"imported":[{"uid":"1111-52","dynamic":true}],"importedBy":[],"isEntry":true},"1111-52":{"id":"/test/e2e/file3.js","moduleParts":{"file3-6fe2c43f.js":"1111-53"},"imported":[],"importedBy":[{"uid":"1111-50"}]},"1111-54":{"id":"/test/e2e/node_modules/module/test.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-48"}]},"1111-55":{"id":"jquery","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-48"}],"isExternal":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"input.js","children":[{"name":"test/e2e/input.js","uid":"1111-49"}]},{"name":"input2.js","children":[{"name":"test/e2e/input2.js","uid":"1111-51"}]},{"name":"file3-6fe2c43f.js","children":[{"name":"test/e2e/file3.js","uid":"1111-53"}]}],"isRoot":true},"nodeParts":{"1111-49":{"renderedLength":67,"gzipLength":80,"brotliLength":68,"metaUid":"1111-48"},"1111-51":{"renderedLength":81,"gzipLength":95,"brotliLength":82,"metaUid":"1111-50"},"1111-53":{"renderedLength":19,"gzipLength":39,"brotliLength":23,"metaUid":"1111-52"}},"nodeMetas":{"1111-48":{"id":"/test/e2e/input.js","moduleParts":{"input.js":"1111-49"},"imported":[{"uid":"1111-54"},{"uid":"1111-55"}],"importedBy":[],"isEntry":true},"1111-50":{"id":"/test/e2e/input2.js","moduleParts":{"input2.js":"1111-51"},"imported":[{"uid":"1111-52","dynamic":true}],"importedBy":[],"isEntry":true},"1111-52":{"id":"/test/e2e/file3.js","moduleParts":{"file3-6fe2c43f.js":"1111-53"},"imported":[],"importedBy":[{"uid":"1111-50"}]},"1111-54":{"id":"/test/e2e/node_modules/module/test.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-48"}]},"1111-55":{"id":"jquery","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-48"}],"isExternal":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":true,"brotli":true,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -19994,7 +20000,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"input.js","children":[{"name":"test/e2e/input.js","uid":"1111-41"}]},{"name":"input2.js","children":[{"name":"test/e2e/input2.js","uid":"1111-43"}]},{"name":"file3-6fe2c43f.js","children":[{"name":"test/e2e/file3.js","uid":"1111-45"}]}],"isRoot":true},"nodeParts":{"1111-41":{"renderedLength":67,"gzipLength":0,"brotliLength":0,"metaUid":"1111-40"},"1111-43":{"renderedLength":81,"gzipLength":0,"brotliLength":0,"metaUid":"1111-42"},"1111-45":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"1111-44"}},"nodeMetas":{"1111-40":{"id":"/test/e2e/input.js","moduleParts":{"input.js":"1111-41"},"imported":[{"uid":"1111-46"},{"uid":"1111-47"}],"importedBy":[],"isEntry":true},"1111-42":{"id":"/test/e2e/input2.js","moduleParts":{"input2.js":"1111-43"},"imported":[{"uid":"1111-44","dynamic":true}],"importedBy":[],"isEntry":true},"1111-44":{"id":"/test/e2e/file3.js","moduleParts":{"file3-6fe2c43f.js":"1111-45"},"imported":[],"importedBy":[{"uid":"1111-42"}]},"1111-46":{"id":"/test/e2e/node_modules/module/test.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-40"}]},"1111-47":{"id":"jquery","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-40"}],"isExternal":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"input.js","children":[{"name":"test/e2e/input.js","uid":"1111-41"}]},{"name":"input2.js","children":[{"name":"test/e2e/input2.js","uid":"1111-43"}]},{"name":"file3-6fe2c43f.js","children":[{"name":"test/e2e/file3.js","uid":"1111-45"}]}],"isRoot":true},"nodeParts":{"1111-41":{"renderedLength":67,"gzipLength":80,"brotliLength":68,"metaUid":"1111-40"},"1111-43":{"renderedLength":81,"gzipLength":95,"brotliLength":82,"metaUid":"1111-42"},"1111-45":{"renderedLength":19,"gzipLength":39,"brotliLength":23,"metaUid":"1111-44"}},"nodeMetas":{"1111-40":{"id":"/test/e2e/input.js","moduleParts":{"input.js":"1111-41"},"imported":[{"uid":"1111-46"},{"uid":"1111-47"}],"importedBy":[],"isEntry":true},"1111-42":{"id":"/test/e2e/input2.js","moduleParts":{"input2.js":"1111-43"},"imported":[{"uid":"1111-44","dynamic":true}],"importedBy":[],"isEntry":true},"1111-44":{"id":"/test/e2e/file3.js","moduleParts":{"file3-6fe2c43f.js":"1111-45"},"imported":[],"importedBy":[{"uid":"1111-42"}]},"1111-46":{"id":"/test/e2e/node_modules/module/test.js","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-40"}]},"1111-47":{"id":"jquery","moduleParts":{},"imported":[],"importedBy":[{"uid":"1111-40"}],"isExternal":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":true,"brotli":true,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;

--- a/test/__snapshots__/gh59.test.ts.snap
+++ b/test/__snapshots__/gh59.test.ts.snap
@@ -4,15 +4,23 @@ exports[`GH-59 sourcemap test - "list" 1`] = `
 "components/A.js:
   /test/gh59/src/components/A.js:
     rendered: 13
+    gzip: 33
+    brotli: 17
 components/B.js:
   /test/gh59/src/components/B.js:
     rendered: 13
+    gzip: 33
+    brotli: 17
 components/index.js:
   /test/gh59/src/components/index.js:
     rendered: 112
+    gzip: 101
+    brotli: 88
 index.js:
   /test/gh59/src/index.js:
     rendered: 19
+    gzip: 37
+    brotli: 23
 "
 `;
 
@@ -6637,7 +6645,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"index.js","children":[{"name":"test/gh59/src/index.js","uid":"1111-57"}]},{"name":"components/A.js","children":[{"name":"test/gh59/src/components/A.js","uid":"1111-59"}]},{"name":"components/B.js","children":[{"name":"test/gh59/src/components/B.js","uid":"1111-61"}]},{"name":"components/index.js","uid":"1111-63"}],"isRoot":true},"nodeParts":{"1111-57":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"1111-56"},"1111-59":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"1111-58"},"1111-61":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"1111-60"},"1111-63":{"id":"components/index.js","gzipLength":0,"brotliLength":0,"renderedLength":112,"metaUid":"1111-62"}},"nodeMetas":{"1111-56":{"id":"/test/gh59/src/index.js","moduleParts":{"index.js":"1111-57"},"imported":[{"uid":"1111-62"}],"importedBy":[],"isEntry":true},"1111-58":{"id":"/test/gh59/src/components/A.js","moduleParts":{"components/A.js":"1111-59"},"imported":[],"importedBy":[{"uid":"1111-62"}],"isEntry":true},"1111-60":{"id":"/test/gh59/src/components/B.js","moduleParts":{"components/B.js":"1111-61"},"imported":[],"importedBy":[{"uid":"1111-62"}],"isEntry":true},"1111-62":{"id":"/test/gh59/src/components/index.js","moduleParts":{"components/index.js":"1111-63"},"imported":[{"uid":"1111-58"},{"uid":"1111-60"}],"importedBy":[{"uid":"1111-56"}],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"index.js","children":[{"name":"test/gh59/src/index.js","uid":"1111-57"}]},{"name":"components/A.js","children":[{"name":"test/gh59/src/components/A.js","uid":"1111-59"}]},{"name":"components/B.js","children":[{"name":"test/gh59/src/components/B.js","uid":"1111-61"}]},{"name":"components/index.js","uid":"1111-63"}],"isRoot":true},"nodeParts":{"1111-57":{"renderedLength":19,"gzipLength":37,"brotliLength":23,"metaUid":"1111-56"},"1111-59":{"renderedLength":13,"gzipLength":33,"brotliLength":17,"metaUid":"1111-58"},"1111-61":{"renderedLength":13,"gzipLength":33,"brotliLength":17,"metaUid":"1111-60"},"1111-63":{"id":"components/index.js","gzipLength":101,"brotliLength":88,"renderedLength":112,"metaUid":"1111-62"}},"nodeMetas":{"1111-56":{"id":"/test/gh59/src/index.js","moduleParts":{"index.js":"1111-57"},"imported":[{"uid":"1111-62"}],"importedBy":[],"isEntry":true},"1111-58":{"id":"/test/gh59/src/components/A.js","moduleParts":{"components/A.js":"1111-59"},"imported":[],"importedBy":[{"uid":"1111-62"}],"isEntry":true},"1111-60":{"id":"/test/gh59/src/components/B.js","moduleParts":{"components/B.js":"1111-61"},"imported":[],"importedBy":[{"uid":"1111-62"}],"isEntry":true},"1111-62":{"id":"/test/gh59/src/components/index.js","moduleParts":{"components/index.js":"1111-63"},"imported":[{"uid":"1111-58"},{"uid":"1111-60"}],"importedBy":[{"uid":"1111-56"}],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":true,"brotli":true,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -6701,26 +6709,26 @@ exports[`GH-59 sourcemap test - "raw-data" 1`] = `
   "nodeParts": {
     "1111-65": {
       "renderedLength": 19,
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 37,
+      "brotliLength": 23,
       "metaUid": "1111-64"
     },
     "1111-67": {
       "renderedLength": 13,
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 33,
+      "brotliLength": 17,
       "metaUid": "1111-66"
     },
     "1111-69": {
       "renderedLength": 13,
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 33,
+      "brotliLength": 17,
       "metaUid": "1111-68"
     },
     "1111-71": {
       "id": "components/index.js",
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 101,
+      "brotliLength": 88,
       "renderedLength": 112,
       "metaUid": "1111-70"
     }
@@ -6790,8 +6798,8 @@ exports[`GH-59 sourcemap test - "raw-data" 1`] = `
     "rollup": "3.9.0"
   },
   "options": {
-    "gzip": false,
-    "brotli": false,
+    "gzip": true,
+    "brotli": true,
     "sourcemap": true
   }
 }"
@@ -13691,7 +13699,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"index.js","children":[{"name":"test/gh59/src/index.js","uid":"1111-49"}]},{"name":"components/A.js","children":[{"name":"test/gh59/src/components/A.js","uid":"1111-51"}]},{"name":"components/B.js","children":[{"name":"test/gh59/src/components/B.js","uid":"1111-53"}]},{"name":"components/index.js","uid":"1111-55"}],"isRoot":true},"nodeParts":{"1111-49":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"1111-48"},"1111-51":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"1111-50"},"1111-53":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"1111-52"},"1111-55":{"id":"components/index.js","gzipLength":0,"brotliLength":0,"renderedLength":112,"metaUid":"1111-54"}},"nodeMetas":{"1111-48":{"id":"/test/gh59/src/index.js","moduleParts":{"index.js":"1111-49"},"imported":[{"uid":"1111-54"}],"importedBy":[],"isEntry":true},"1111-50":{"id":"/test/gh59/src/components/A.js","moduleParts":{"components/A.js":"1111-51"},"imported":[],"importedBy":[{"uid":"1111-54"}],"isEntry":true},"1111-52":{"id":"/test/gh59/src/components/B.js","moduleParts":{"components/B.js":"1111-53"},"imported":[],"importedBy":[{"uid":"1111-54"}],"isEntry":true},"1111-54":{"id":"/test/gh59/src/components/index.js","moduleParts":{"components/index.js":"1111-55"},"imported":[{"uid":"1111-50"},{"uid":"1111-52"}],"importedBy":[{"uid":"1111-48"}],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"index.js","children":[{"name":"test/gh59/src/index.js","uid":"1111-49"}]},{"name":"components/A.js","children":[{"name":"test/gh59/src/components/A.js","uid":"1111-51"}]},{"name":"components/B.js","children":[{"name":"test/gh59/src/components/B.js","uid":"1111-53"}]},{"name":"components/index.js","uid":"1111-55"}],"isRoot":true},"nodeParts":{"1111-49":{"renderedLength":19,"gzipLength":37,"brotliLength":23,"metaUid":"1111-48"},"1111-51":{"renderedLength":13,"gzipLength":33,"brotliLength":17,"metaUid":"1111-50"},"1111-53":{"renderedLength":13,"gzipLength":33,"brotliLength":17,"metaUid":"1111-52"},"1111-55":{"id":"components/index.js","gzipLength":101,"brotliLength":88,"renderedLength":112,"metaUid":"1111-54"}},"nodeMetas":{"1111-48":{"id":"/test/gh59/src/index.js","moduleParts":{"index.js":"1111-49"},"imported":[{"uid":"1111-54"}],"importedBy":[],"isEntry":true},"1111-50":{"id":"/test/gh59/src/components/A.js","moduleParts":{"components/A.js":"1111-51"},"imported":[],"importedBy":[{"uid":"1111-54"}],"isEntry":true},"1111-52":{"id":"/test/gh59/src/components/B.js","moduleParts":{"components/B.js":"1111-53"},"imported":[],"importedBy":[{"uid":"1111-54"}],"isEntry":true},"1111-54":{"id":"/test/gh59/src/components/index.js","moduleParts":{"components/index.js":"1111-55"},"imported":[{"uid":"1111-50"},{"uid":"1111-52"}],"importedBy":[{"uid":"1111-48"}],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":true,"brotli":true,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -19872,7 +19880,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"index.js","children":[{"name":"test/gh59/src/index.js","uid":"1111-41"}]},{"name":"components/A.js","children":[{"name":"test/gh59/src/components/A.js","uid":"1111-43"}]},{"name":"components/B.js","children":[{"name":"test/gh59/src/components/B.js","uid":"1111-45"}]},{"name":"components/index.js","uid":"1111-47"}],"isRoot":true},"nodeParts":{"1111-41":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"1111-40"},"1111-43":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"1111-42"},"1111-45":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"1111-44"},"1111-47":{"id":"components/index.js","gzipLength":0,"brotliLength":0,"renderedLength":112,"metaUid":"1111-46"}},"nodeMetas":{"1111-40":{"id":"/test/gh59/src/index.js","moduleParts":{"index.js":"1111-41"},"imported":[{"uid":"1111-46"}],"importedBy":[],"isEntry":true},"1111-42":{"id":"/test/gh59/src/components/A.js","moduleParts":{"components/A.js":"1111-43"},"imported":[],"importedBy":[{"uid":"1111-46"}],"isEntry":true},"1111-44":{"id":"/test/gh59/src/components/B.js","moduleParts":{"components/B.js":"1111-45"},"imported":[],"importedBy":[{"uid":"1111-46"}],"isEntry":true},"1111-46":{"id":"/test/gh59/src/components/index.js","moduleParts":{"components/index.js":"1111-47"},"imported":[{"uid":"1111-42"},{"uid":"1111-44"}],"importedBy":[{"uid":"1111-40"}],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"index.js","children":[{"name":"test/gh59/src/index.js","uid":"1111-41"}]},{"name":"components/A.js","children":[{"name":"test/gh59/src/components/A.js","uid":"1111-43"}]},{"name":"components/B.js","children":[{"name":"test/gh59/src/components/B.js","uid":"1111-45"}]},{"name":"components/index.js","uid":"1111-47"}],"isRoot":true},"nodeParts":{"1111-41":{"renderedLength":19,"gzipLength":37,"brotliLength":23,"metaUid":"1111-40"},"1111-43":{"renderedLength":13,"gzipLength":33,"brotliLength":17,"metaUid":"1111-42"},"1111-45":{"renderedLength":13,"gzipLength":33,"brotliLength":17,"metaUid":"1111-44"},"1111-47":{"id":"components/index.js","gzipLength":101,"brotliLength":88,"renderedLength":112,"metaUid":"1111-46"}},"nodeMetas":{"1111-40":{"id":"/test/gh59/src/index.js","moduleParts":{"index.js":"1111-41"},"imported":[{"uid":"1111-46"}],"importedBy":[],"isEntry":true},"1111-42":{"id":"/test/gh59/src/components/A.js","moduleParts":{"components/A.js":"1111-43"},"imported":[],"importedBy":[{"uid":"1111-46"}],"isEntry":true},"1111-44":{"id":"/test/gh59/src/components/B.js","moduleParts":{"components/B.js":"1111-45"},"imported":[],"importedBy":[{"uid":"1111-46"}],"isEntry":true},"1111-46":{"id":"/test/gh59/src/components/index.js","moduleParts":{"components/index.js":"1111-47"},"imported":[{"uid":"1111-42"},{"uid":"1111-44"}],"importedBy":[{"uid":"1111-40"}],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":true,"brotli":true,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;

--- a/test/__snapshots__/gh59.test.ts.snap
+++ b/test/__snapshots__/gh59.test.ts.snap
@@ -3,16 +3,16 @@
 exports[`GH-59 sourcemap test - "list" 1`] = `
 "components/A.js:
   /test/gh59/src/components/A.js:
-    rendered: 12
+    rendered: 13
 components/B.js:
   /test/gh59/src/components/B.js:
-    rendered: 12
+    rendered: 13
 components/index.js:
   /test/gh59/src/components/index.js:
     rendered: 112
 index.js:
   /test/gh59/src/index.js:
-    rendered: 18
+    rendered: 19
 "
 `;
 
@@ -6637,7 +6637,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"index.js","children":[{"name":"test/gh59/src/index.js","uid":"1111-57"}]},{"name":"components/A.js","children":[{"name":"test/gh59/src/components/A.js","uid":"1111-59"}]},{"name":"components/B.js","children":[{"name":"test/gh59/src/components/B.js","uid":"1111-61"}]},{"name":"components/index.js","uid":"1111-63"}],"isRoot":true},"nodeParts":{"1111-57":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"1111-56"},"1111-59":{"renderedLength":12,"gzipLength":0,"brotliLength":0,"metaUid":"1111-58"},"1111-61":{"renderedLength":12,"gzipLength":0,"brotliLength":0,"metaUid":"1111-60"},"1111-63":{"id":"components/index.js","gzipLength":0,"brotliLength":0,"renderedLength":112,"metaUid":"1111-62"}},"nodeMetas":{"1111-56":{"id":"/test/gh59/src/index.js","moduleParts":{"index.js":"1111-57"},"imported":[{"uid":"1111-62"}],"importedBy":[],"isEntry":true},"1111-58":{"id":"/test/gh59/src/components/A.js","moduleParts":{"components/A.js":"1111-59"},"imported":[],"importedBy":[{"uid":"1111-62"}],"isEntry":true},"1111-60":{"id":"/test/gh59/src/components/B.js","moduleParts":{"components/B.js":"1111-61"},"imported":[],"importedBy":[{"uid":"1111-62"}],"isEntry":true},"1111-62":{"id":"/test/gh59/src/components/index.js","moduleParts":{"components/index.js":"1111-63"},"imported":[{"uid":"1111-58"},{"uid":"1111-60"}],"importedBy":[{"uid":"1111-56"}],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"index.js","children":[{"name":"test/gh59/src/index.js","uid":"1111-57"}]},{"name":"components/A.js","children":[{"name":"test/gh59/src/components/A.js","uid":"1111-59"}]},{"name":"components/B.js","children":[{"name":"test/gh59/src/components/B.js","uid":"1111-61"}]},{"name":"components/index.js","uid":"1111-63"}],"isRoot":true},"nodeParts":{"1111-57":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"1111-56"},"1111-59":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"1111-58"},"1111-61":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"1111-60"},"1111-63":{"id":"components/index.js","gzipLength":0,"brotliLength":0,"renderedLength":112,"metaUid":"1111-62"}},"nodeMetas":{"1111-56":{"id":"/test/gh59/src/index.js","moduleParts":{"index.js":"1111-57"},"imported":[{"uid":"1111-62"}],"importedBy":[],"isEntry":true},"1111-58":{"id":"/test/gh59/src/components/A.js","moduleParts":{"components/A.js":"1111-59"},"imported":[],"importedBy":[{"uid":"1111-62"}],"isEntry":true},"1111-60":{"id":"/test/gh59/src/components/B.js","moduleParts":{"components/B.js":"1111-61"},"imported":[],"importedBy":[{"uid":"1111-62"}],"isEntry":true},"1111-62":{"id":"/test/gh59/src/components/index.js","moduleParts":{"components/index.js":"1111-63"},"imported":[{"uid":"1111-58"},{"uid":"1111-60"}],"importedBy":[{"uid":"1111-56"}],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -6700,19 +6700,19 @@ exports[`GH-59 sourcemap test - "raw-data" 1`] = `
   },
   "nodeParts": {
     "1111-65": {
-      "renderedLength": 18,
+      "renderedLength": 19,
       "gzipLength": 0,
       "brotliLength": 0,
       "metaUid": "1111-64"
     },
     "1111-67": {
-      "renderedLength": 12,
+      "renderedLength": 13,
       "gzipLength": 0,
       "brotliLength": 0,
       "metaUid": "1111-66"
     },
     "1111-69": {
-      "renderedLength": 12,
+      "renderedLength": 13,
       "gzipLength": 0,
       "brotliLength": 0,
       "metaUid": "1111-68"
@@ -13691,7 +13691,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"index.js","children":[{"name":"test/gh59/src/index.js","uid":"1111-49"}]},{"name":"components/A.js","children":[{"name":"test/gh59/src/components/A.js","uid":"1111-51"}]},{"name":"components/B.js","children":[{"name":"test/gh59/src/components/B.js","uid":"1111-53"}]},{"name":"components/index.js","uid":"1111-55"}],"isRoot":true},"nodeParts":{"1111-49":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"1111-48"},"1111-51":{"renderedLength":12,"gzipLength":0,"brotliLength":0,"metaUid":"1111-50"},"1111-53":{"renderedLength":12,"gzipLength":0,"brotliLength":0,"metaUid":"1111-52"},"1111-55":{"id":"components/index.js","gzipLength":0,"brotliLength":0,"renderedLength":112,"metaUid":"1111-54"}},"nodeMetas":{"1111-48":{"id":"/test/gh59/src/index.js","moduleParts":{"index.js":"1111-49"},"imported":[{"uid":"1111-54"}],"importedBy":[],"isEntry":true},"1111-50":{"id":"/test/gh59/src/components/A.js","moduleParts":{"components/A.js":"1111-51"},"imported":[],"importedBy":[{"uid":"1111-54"}],"isEntry":true},"1111-52":{"id":"/test/gh59/src/components/B.js","moduleParts":{"components/B.js":"1111-53"},"imported":[],"importedBy":[{"uid":"1111-54"}],"isEntry":true},"1111-54":{"id":"/test/gh59/src/components/index.js","moduleParts":{"components/index.js":"1111-55"},"imported":[{"uid":"1111-50"},{"uid":"1111-52"}],"importedBy":[{"uid":"1111-48"}],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"index.js","children":[{"name":"test/gh59/src/index.js","uid":"1111-49"}]},{"name":"components/A.js","children":[{"name":"test/gh59/src/components/A.js","uid":"1111-51"}]},{"name":"components/B.js","children":[{"name":"test/gh59/src/components/B.js","uid":"1111-53"}]},{"name":"components/index.js","uid":"1111-55"}],"isRoot":true},"nodeParts":{"1111-49":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"1111-48"},"1111-51":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"1111-50"},"1111-53":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"1111-52"},"1111-55":{"id":"components/index.js","gzipLength":0,"brotliLength":0,"renderedLength":112,"metaUid":"1111-54"}},"nodeMetas":{"1111-48":{"id":"/test/gh59/src/index.js","moduleParts":{"index.js":"1111-49"},"imported":[{"uid":"1111-54"}],"importedBy":[],"isEntry":true},"1111-50":{"id":"/test/gh59/src/components/A.js","moduleParts":{"components/A.js":"1111-51"},"imported":[],"importedBy":[{"uid":"1111-54"}],"isEntry":true},"1111-52":{"id":"/test/gh59/src/components/B.js","moduleParts":{"components/B.js":"1111-53"},"imported":[],"importedBy":[{"uid":"1111-54"}],"isEntry":true},"1111-54":{"id":"/test/gh59/src/components/index.js","moduleParts":{"components/index.js":"1111-55"},"imported":[{"uid":"1111-50"},{"uid":"1111-52"}],"importedBy":[{"uid":"1111-48"}],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -19872,7 +19872,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"index.js","children":[{"name":"test/gh59/src/index.js","uid":"1111-41"}]},{"name":"components/A.js","children":[{"name":"test/gh59/src/components/A.js","uid":"1111-43"}]},{"name":"components/B.js","children":[{"name":"test/gh59/src/components/B.js","uid":"1111-45"}]},{"name":"components/index.js","uid":"1111-47"}],"isRoot":true},"nodeParts":{"1111-41":{"renderedLength":18,"gzipLength":0,"brotliLength":0,"metaUid":"1111-40"},"1111-43":{"renderedLength":12,"gzipLength":0,"brotliLength":0,"metaUid":"1111-42"},"1111-45":{"renderedLength":12,"gzipLength":0,"brotliLength":0,"metaUid":"1111-44"},"1111-47":{"id":"components/index.js","gzipLength":0,"brotliLength":0,"renderedLength":112,"metaUid":"1111-46"}},"nodeMetas":{"1111-40":{"id":"/test/gh59/src/index.js","moduleParts":{"index.js":"1111-41"},"imported":[{"uid":"1111-46"}],"importedBy":[],"isEntry":true},"1111-42":{"id":"/test/gh59/src/components/A.js","moduleParts":{"components/A.js":"1111-43"},"imported":[],"importedBy":[{"uid":"1111-46"}],"isEntry":true},"1111-44":{"id":"/test/gh59/src/components/B.js","moduleParts":{"components/B.js":"1111-45"},"imported":[],"importedBy":[{"uid":"1111-46"}],"isEntry":true},"1111-46":{"id":"/test/gh59/src/components/index.js","moduleParts":{"components/index.js":"1111-47"},"imported":[{"uid":"1111-42"},{"uid":"1111-44"}],"importedBy":[{"uid":"1111-40"}],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"index.js","children":[{"name":"test/gh59/src/index.js","uid":"1111-41"}]},{"name":"components/A.js","children":[{"name":"test/gh59/src/components/A.js","uid":"1111-43"}]},{"name":"components/B.js","children":[{"name":"test/gh59/src/components/B.js","uid":"1111-45"}]},{"name":"components/index.js","uid":"1111-47"}],"isRoot":true},"nodeParts":{"1111-41":{"renderedLength":19,"gzipLength":0,"brotliLength":0,"metaUid":"1111-40"},"1111-43":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"1111-42"},"1111-45":{"renderedLength":13,"gzipLength":0,"brotliLength":0,"metaUid":"1111-44"},"1111-47":{"id":"components/index.js","gzipLength":0,"brotliLength":0,"renderedLength":112,"metaUid":"1111-46"}},"nodeMetas":{"1111-40":{"id":"/test/gh59/src/index.js","moduleParts":{"index.js":"1111-41"},"imported":[{"uid":"1111-46"}],"importedBy":[],"isEntry":true},"1111-42":{"id":"/test/gh59/src/components/A.js","moduleParts":{"components/A.js":"1111-43"},"imported":[],"importedBy":[{"uid":"1111-46"}],"isEntry":true},"1111-44":{"id":"/test/gh59/src/components/B.js","moduleParts":{"components/B.js":"1111-45"},"imported":[],"importedBy":[{"uid":"1111-46"}],"isEntry":true},"1111-46":{"id":"/test/gh59/src/components/index.js","moduleParts":{"components/index.js":"1111-47"},"imported":[{"uid":"1111-42"},{"uid":"1111-44"}],"importedBy":[{"uid":"1111-40"}],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;

--- a/test/__snapshots__/gh69.test.ts.snap
+++ b/test/__snapshots__/gh69.test.ts.snap
@@ -3,12 +3,12 @@
 exports[`GH-69 sourcemap test - "list" 1`] = `
 "dynamic-a5dd5b16.js:
   /test/gh69/dynamic.js:
-    rendered: 6
+    rendered: 7
 main.js:
   /test/gh69/lib.js:
-    rendered: 86
+    rendered: 87
   /test/gh69/main.js:
-    rendered: 84
+    rendered: 85
 "
 `;
 
@@ -6633,7 +6633,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","children":[{"name":"test/gh69","children":[{"uid":"1111-43","name":"lib.js"},{"uid":"1111-45","name":"main.js"}]}]},{"name":"dynamic-a5dd5b16.js","children":[{"name":"test/gh69/dynamic.js","uid":"1111-47"}]}],"isRoot":true},"nodeParts":{"1111-43":{"renderedLength":86,"gzipLength":0,"brotliLength":0,"metaUid":"1111-42"},"1111-45":{"renderedLength":84,"gzipLength":0,"brotliLength":0,"metaUid":"1111-44"},"1111-47":{"renderedLength":6,"gzipLength":0,"brotliLength":0,"metaUid":"1111-46"}},"nodeMetas":{"1111-42":{"id":"/test/gh69/lib.js","moduleParts":{"main.js":"1111-43"},"imported":[],"importedBy":[{"uid":"1111-44"},{"uid":"1111-46"}]},"1111-44":{"id":"/test/gh69/main.js","moduleParts":{"main.js":"1111-45"},"imported":[{"uid":"1111-42"},{"uid":"1111-46","dynamic":true}],"importedBy":[],"isEntry":true},"1111-46":{"id":"/test/gh69/dynamic.js","moduleParts":{"dynamic-a5dd5b16.js":"1111-47"},"imported":[{"uid":"1111-42"}],"importedBy":[{"uid":"1111-44"}]}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","children":[{"name":"test/gh69","children":[{"uid":"1111-43","name":"lib.js"},{"uid":"1111-45","name":"main.js"}]}]},{"name":"dynamic-a5dd5b16.js","children":[{"name":"test/gh69/dynamic.js","uid":"1111-47"}]}],"isRoot":true},"nodeParts":{"1111-43":{"renderedLength":87,"gzipLength":0,"brotliLength":0,"metaUid":"1111-42"},"1111-45":{"renderedLength":85,"gzipLength":0,"brotliLength":0,"metaUid":"1111-44"},"1111-47":{"renderedLength":7,"gzipLength":0,"brotliLength":0,"metaUid":"1111-46"}},"nodeMetas":{"1111-42":{"id":"/test/gh69/lib.js","moduleParts":{"main.js":"1111-43"},"imported":[],"importedBy":[{"uid":"1111-44"},{"uid":"1111-46"}]},"1111-44":{"id":"/test/gh69/main.js","moduleParts":{"main.js":"1111-45"},"imported":[{"uid":"1111-42"},{"uid":"1111-46","dynamic":true}],"importedBy":[],"isEntry":true},"1111-46":{"id":"/test/gh69/dynamic.js","moduleParts":{"dynamic-a5dd5b16.js":"1111-47"},"imported":[{"uid":"1111-42"}],"importedBy":[{"uid":"1111-44"}]}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -6692,19 +6692,19 @@ exports[`GH-69 sourcemap test - "raw-data" 1`] = `
   },
   "nodeParts": {
     "1111-49": {
-      "renderedLength": 86,
+      "renderedLength": 87,
       "gzipLength": 0,
       "brotliLength": 0,
       "metaUid": "1111-48"
     },
     "1111-51": {
-      "renderedLength": 84,
+      "renderedLength": 85,
       "gzipLength": 0,
       "brotliLength": 0,
       "metaUid": "1111-50"
     },
     "1111-53": {
-      "renderedLength": 6,
+      "renderedLength": 7,
       "gzipLength": 0,
       "brotliLength": 0,
       "metaUid": "1111-52"
@@ -13665,7 +13665,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","children":[{"name":"test/gh69","children":[{"uid":"1111-37","name":"lib.js"},{"uid":"1111-39","name":"main.js"}]}]},{"name":"dynamic-a5dd5b16.js","children":[{"name":"test/gh69/dynamic.js","uid":"1111-41"}]}],"isRoot":true},"nodeParts":{"1111-37":{"renderedLength":86,"gzipLength":0,"brotliLength":0,"metaUid":"1111-36"},"1111-39":{"renderedLength":84,"gzipLength":0,"brotliLength":0,"metaUid":"1111-38"},"1111-41":{"renderedLength":6,"gzipLength":0,"brotliLength":0,"metaUid":"1111-40"}},"nodeMetas":{"1111-36":{"id":"/test/gh69/lib.js","moduleParts":{"main.js":"1111-37"},"imported":[],"importedBy":[{"uid":"1111-38"},{"uid":"1111-40"}]},"1111-38":{"id":"/test/gh69/main.js","moduleParts":{"main.js":"1111-39"},"imported":[{"uid":"1111-36"},{"uid":"1111-40","dynamic":true}],"importedBy":[],"isEntry":true},"1111-40":{"id":"/test/gh69/dynamic.js","moduleParts":{"dynamic-a5dd5b16.js":"1111-41"},"imported":[{"uid":"1111-36"}],"importedBy":[{"uid":"1111-38"}]}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","children":[{"name":"test/gh69","children":[{"uid":"1111-37","name":"lib.js"},{"uid":"1111-39","name":"main.js"}]}]},{"name":"dynamic-a5dd5b16.js","children":[{"name":"test/gh69/dynamic.js","uid":"1111-41"}]}],"isRoot":true},"nodeParts":{"1111-37":{"renderedLength":87,"gzipLength":0,"brotliLength":0,"metaUid":"1111-36"},"1111-39":{"renderedLength":85,"gzipLength":0,"brotliLength":0,"metaUid":"1111-38"},"1111-41":{"renderedLength":7,"gzipLength":0,"brotliLength":0,"metaUid":"1111-40"}},"nodeMetas":{"1111-36":{"id":"/test/gh69/lib.js","moduleParts":{"main.js":"1111-37"},"imported":[],"importedBy":[{"uid":"1111-38"},{"uid":"1111-40"}]},"1111-38":{"id":"/test/gh69/main.js","moduleParts":{"main.js":"1111-39"},"imported":[{"uid":"1111-36"},{"uid":"1111-40","dynamic":true}],"importedBy":[],"isEntry":true},"1111-40":{"id":"/test/gh69/dynamic.js","moduleParts":{"dynamic-a5dd5b16.js":"1111-41"},"imported":[{"uid":"1111-36"}],"importedBy":[{"uid":"1111-38"}]}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -19846,7 +19846,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","children":[{"name":"test/gh69","children":[{"uid":"1111-31","name":"lib.js"},{"uid":"1111-33","name":"main.js"}]}]},{"name":"dynamic-a5dd5b16.js","children":[{"name":"test/gh69/dynamic.js","uid":"1111-35"}]}],"isRoot":true},"nodeParts":{"1111-31":{"renderedLength":86,"gzipLength":0,"brotliLength":0,"metaUid":"1111-30"},"1111-33":{"renderedLength":84,"gzipLength":0,"brotliLength":0,"metaUid":"1111-32"},"1111-35":{"renderedLength":6,"gzipLength":0,"brotliLength":0,"metaUid":"1111-34"}},"nodeMetas":{"1111-30":{"id":"/test/gh69/lib.js","moduleParts":{"main.js":"1111-31"},"imported":[],"importedBy":[{"uid":"1111-32"},{"uid":"1111-34"}]},"1111-32":{"id":"/test/gh69/main.js","moduleParts":{"main.js":"1111-33"},"imported":[{"uid":"1111-30"},{"uid":"1111-34","dynamic":true}],"importedBy":[],"isEntry":true},"1111-34":{"id":"/test/gh69/dynamic.js","moduleParts":{"dynamic-a5dd5b16.js":"1111-35"},"imported":[{"uid":"1111-30"}],"importedBy":[{"uid":"1111-32"}]}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","children":[{"name":"test/gh69","children":[{"uid":"1111-31","name":"lib.js"},{"uid":"1111-33","name":"main.js"}]}]},{"name":"dynamic-a5dd5b16.js","children":[{"name":"test/gh69/dynamic.js","uid":"1111-35"}]}],"isRoot":true},"nodeParts":{"1111-31":{"renderedLength":87,"gzipLength":0,"brotliLength":0,"metaUid":"1111-30"},"1111-33":{"renderedLength":85,"gzipLength":0,"brotliLength":0,"metaUid":"1111-32"},"1111-35":{"renderedLength":7,"gzipLength":0,"brotliLength":0,"metaUid":"1111-34"}},"nodeMetas":{"1111-30":{"id":"/test/gh69/lib.js","moduleParts":{"main.js":"1111-31"},"imported":[],"importedBy":[{"uid":"1111-32"},{"uid":"1111-34"}]},"1111-32":{"id":"/test/gh69/main.js","moduleParts":{"main.js":"1111-33"},"imported":[{"uid":"1111-30"},{"uid":"1111-34","dynamic":true}],"importedBy":[],"isEntry":true},"1111-34":{"id":"/test/gh69/dynamic.js","moduleParts":{"dynamic-a5dd5b16.js":"1111-35"},"imported":[{"uid":"1111-30"}],"importedBy":[{"uid":"1111-32"}]}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;

--- a/test/__snapshots__/gh69.test.ts.snap
+++ b/test/__snapshots__/gh69.test.ts.snap
@@ -4,11 +4,17 @@ exports[`GH-69 sourcemap test - "list" 1`] = `
 "dynamic-a5dd5b16.js:
   /test/gh69/dynamic.js:
     rendered: 7
+    gzip: 27
+    brotli: 11
 main.js:
   /test/gh69/lib.js:
     rendered: 87
+    gzip: 73
+    brotli: 67
   /test/gh69/main.js:
     rendered: 85
+    gzip: 98
+    brotli: 89
 "
 `;
 
@@ -6633,7 +6639,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","children":[{"name":"test/gh69","children":[{"uid":"1111-43","name":"lib.js"},{"uid":"1111-45","name":"main.js"}]}]},{"name":"dynamic-a5dd5b16.js","children":[{"name":"test/gh69/dynamic.js","uid":"1111-47"}]}],"isRoot":true},"nodeParts":{"1111-43":{"renderedLength":87,"gzipLength":0,"brotliLength":0,"metaUid":"1111-42"},"1111-45":{"renderedLength":85,"gzipLength":0,"brotliLength":0,"metaUid":"1111-44"},"1111-47":{"renderedLength":7,"gzipLength":0,"brotliLength":0,"metaUid":"1111-46"}},"nodeMetas":{"1111-42":{"id":"/test/gh69/lib.js","moduleParts":{"main.js":"1111-43"},"imported":[],"importedBy":[{"uid":"1111-44"},{"uid":"1111-46"}]},"1111-44":{"id":"/test/gh69/main.js","moduleParts":{"main.js":"1111-45"},"imported":[{"uid":"1111-42"},{"uid":"1111-46","dynamic":true}],"importedBy":[],"isEntry":true},"1111-46":{"id":"/test/gh69/dynamic.js","moduleParts":{"dynamic-a5dd5b16.js":"1111-47"},"imported":[{"uid":"1111-42"}],"importedBy":[{"uid":"1111-44"}]}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","children":[{"name":"test/gh69","children":[{"uid":"1111-43","name":"lib.js"},{"uid":"1111-45","name":"main.js"}]}]},{"name":"dynamic-a5dd5b16.js","children":[{"name":"test/gh69/dynamic.js","uid":"1111-47"}]}],"isRoot":true},"nodeParts":{"1111-43":{"renderedLength":87,"gzipLength":73,"brotliLength":67,"metaUid":"1111-42"},"1111-45":{"renderedLength":85,"gzipLength":98,"brotliLength":89,"metaUid":"1111-44"},"1111-47":{"renderedLength":7,"gzipLength":27,"brotliLength":11,"metaUid":"1111-46"}},"nodeMetas":{"1111-42":{"id":"/test/gh69/lib.js","moduleParts":{"main.js":"1111-43"},"imported":[],"importedBy":[{"uid":"1111-44"},{"uid":"1111-46"}]},"1111-44":{"id":"/test/gh69/main.js","moduleParts":{"main.js":"1111-45"},"imported":[{"uid":"1111-42"},{"uid":"1111-46","dynamic":true}],"importedBy":[],"isEntry":true},"1111-46":{"id":"/test/gh69/dynamic.js","moduleParts":{"dynamic-a5dd5b16.js":"1111-47"},"imported":[{"uid":"1111-42"}],"importedBy":[{"uid":"1111-44"}]}},"env":{"rollup":"3.9.0"},"options":{"gzip":true,"brotli":true,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -6693,20 +6699,20 @@ exports[`GH-69 sourcemap test - "raw-data" 1`] = `
   "nodeParts": {
     "1111-49": {
       "renderedLength": 87,
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 73,
+      "brotliLength": 67,
       "metaUid": "1111-48"
     },
     "1111-51": {
       "renderedLength": 85,
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 98,
+      "brotliLength": 89,
       "metaUid": "1111-50"
     },
     "1111-53": {
       "renderedLength": 7,
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 27,
+      "brotliLength": 11,
       "metaUid": "1111-52"
     }
   },
@@ -6764,8 +6770,8 @@ exports[`GH-69 sourcemap test - "raw-data" 1`] = `
     "rollup": "3.9.0"
   },
   "options": {
-    "gzip": false,
-    "brotli": false,
+    "gzip": true,
+    "brotli": true,
     "sourcemap": true
   }
 }"
@@ -13665,7 +13671,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","children":[{"name":"test/gh69","children":[{"uid":"1111-37","name":"lib.js"},{"uid":"1111-39","name":"main.js"}]}]},{"name":"dynamic-a5dd5b16.js","children":[{"name":"test/gh69/dynamic.js","uid":"1111-41"}]}],"isRoot":true},"nodeParts":{"1111-37":{"renderedLength":87,"gzipLength":0,"brotliLength":0,"metaUid":"1111-36"},"1111-39":{"renderedLength":85,"gzipLength":0,"brotliLength":0,"metaUid":"1111-38"},"1111-41":{"renderedLength":7,"gzipLength":0,"brotliLength":0,"metaUid":"1111-40"}},"nodeMetas":{"1111-36":{"id":"/test/gh69/lib.js","moduleParts":{"main.js":"1111-37"},"imported":[],"importedBy":[{"uid":"1111-38"},{"uid":"1111-40"}]},"1111-38":{"id":"/test/gh69/main.js","moduleParts":{"main.js":"1111-39"},"imported":[{"uid":"1111-36"},{"uid":"1111-40","dynamic":true}],"importedBy":[],"isEntry":true},"1111-40":{"id":"/test/gh69/dynamic.js","moduleParts":{"dynamic-a5dd5b16.js":"1111-41"},"imported":[{"uid":"1111-36"}],"importedBy":[{"uid":"1111-38"}]}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","children":[{"name":"test/gh69","children":[{"uid":"1111-37","name":"lib.js"},{"uid":"1111-39","name":"main.js"}]}]},{"name":"dynamic-a5dd5b16.js","children":[{"name":"test/gh69/dynamic.js","uid":"1111-41"}]}],"isRoot":true},"nodeParts":{"1111-37":{"renderedLength":87,"gzipLength":73,"brotliLength":67,"metaUid":"1111-36"},"1111-39":{"renderedLength":85,"gzipLength":98,"brotliLength":89,"metaUid":"1111-38"},"1111-41":{"renderedLength":7,"gzipLength":27,"brotliLength":11,"metaUid":"1111-40"}},"nodeMetas":{"1111-36":{"id":"/test/gh69/lib.js","moduleParts":{"main.js":"1111-37"},"imported":[],"importedBy":[{"uid":"1111-38"},{"uid":"1111-40"}]},"1111-38":{"id":"/test/gh69/main.js","moduleParts":{"main.js":"1111-39"},"imported":[{"uid":"1111-36"},{"uid":"1111-40","dynamic":true}],"importedBy":[],"isEntry":true},"1111-40":{"id":"/test/gh69/dynamic.js","moduleParts":{"dynamic-a5dd5b16.js":"1111-41"},"imported":[{"uid":"1111-36"}],"importedBy":[{"uid":"1111-38"}]}},"env":{"rollup":"3.9.0"},"options":{"gzip":true,"brotli":true,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -19846,7 +19852,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","children":[{"name":"test/gh69","children":[{"uid":"1111-31","name":"lib.js"},{"uid":"1111-33","name":"main.js"}]}]},{"name":"dynamic-a5dd5b16.js","children":[{"name":"test/gh69/dynamic.js","uid":"1111-35"}]}],"isRoot":true},"nodeParts":{"1111-31":{"renderedLength":87,"gzipLength":0,"brotliLength":0,"metaUid":"1111-30"},"1111-33":{"renderedLength":85,"gzipLength":0,"brotliLength":0,"metaUid":"1111-32"},"1111-35":{"renderedLength":7,"gzipLength":0,"brotliLength":0,"metaUid":"1111-34"}},"nodeMetas":{"1111-30":{"id":"/test/gh69/lib.js","moduleParts":{"main.js":"1111-31"},"imported":[],"importedBy":[{"uid":"1111-32"},{"uid":"1111-34"}]},"1111-32":{"id":"/test/gh69/main.js","moduleParts":{"main.js":"1111-33"},"imported":[{"uid":"1111-30"},{"uid":"1111-34","dynamic":true}],"importedBy":[],"isEntry":true},"1111-34":{"id":"/test/gh69/dynamic.js","moduleParts":{"dynamic-a5dd5b16.js":"1111-35"},"imported":[{"uid":"1111-30"}],"importedBy":[{"uid":"1111-32"}]}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","children":[{"name":"test/gh69","children":[{"uid":"1111-31","name":"lib.js"},{"uid":"1111-33","name":"main.js"}]}]},{"name":"dynamic-a5dd5b16.js","children":[{"name":"test/gh69/dynamic.js","uid":"1111-35"}]}],"isRoot":true},"nodeParts":{"1111-31":{"renderedLength":87,"gzipLength":73,"brotliLength":67,"metaUid":"1111-30"},"1111-33":{"renderedLength":85,"gzipLength":98,"brotliLength":89,"metaUid":"1111-32"},"1111-35":{"renderedLength":7,"gzipLength":27,"brotliLength":11,"metaUid":"1111-34"}},"nodeMetas":{"1111-30":{"id":"/test/gh69/lib.js","moduleParts":{"main.js":"1111-31"},"imported":[],"importedBy":[{"uid":"1111-32"},{"uid":"1111-34"}]},"1111-32":{"id":"/test/gh69/main.js","moduleParts":{"main.js":"1111-33"},"imported":[{"uid":"1111-30"},{"uid":"1111-34","dynamic":true}],"importedBy":[],"isEntry":true},"1111-34":{"id":"/test/gh69/dynamic.js","moduleParts":{"dynamic-a5dd5b16.js":"1111-35"},"imported":[{"uid":"1111-30"}],"importedBy":[{"uid":"1111-32"}]}},"env":{"rollup":"3.9.0"},"options":{"gzip":true,"brotli":true,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;

--- a/test/__snapshots__/gh93.test.ts.snap
+++ b/test/__snapshots__/gh93.test.ts.snap
@@ -4,9 +4,13 @@ exports[`GH-93 sourcemap test - "list" 1`] = `
 "main.js:
   /test/gh93/main.js:
     rendered: 84
+    gzip: 98
+    brotli: 83
 virtual-id-7429d3ba.js:
   virtual-id:
     rendered: 75
+    gzip: 87
+    brotli: 68
 "
 `;
 
@@ -6631,7 +6635,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","uid":"1111-29"},{"name":"virtual-id-7429d3ba.js","uid":"1111-31"}],"isRoot":true},"nodeParts":{"1111-29":{"id":"main.js","gzipLength":0,"brotliLength":0,"renderedLength":84,"metaUid":"1111-28"},"1111-31":{"id":"virtual-id-7429d3ba.js","gzipLength":0,"brotliLength":0,"renderedLength":75,"metaUid":"1111-30"}},"nodeMetas":{"1111-28":{"id":"/test/gh93/main.js","moduleParts":{"main.js":"1111-29"},"imported":[],"importedBy":[],"isEntry":true},"1111-30":{"id":"virtual-id","moduleParts":{"virtual-id-7429d3ba.js":"1111-31"},"imported":[],"importedBy":[],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","uid":"1111-29"},{"name":"virtual-id-7429d3ba.js","uid":"1111-31"}],"isRoot":true},"nodeParts":{"1111-29":{"id":"main.js","gzipLength":98,"brotliLength":83,"renderedLength":84,"metaUid":"1111-28"},"1111-31":{"id":"virtual-id-7429d3ba.js","gzipLength":87,"brotliLength":68,"renderedLength":75,"metaUid":"1111-30"}},"nodeMetas":{"1111-28":{"id":"/test/gh93/main.js","moduleParts":{"main.js":"1111-29"},"imported":[],"importedBy":[],"isEntry":true},"1111-30":{"id":"virtual-id","moduleParts":{"virtual-id-7429d3ba.js":"1111-31"},"imported":[],"importedBy":[],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":true,"brotli":true,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -6672,15 +6676,15 @@ exports[`GH-93 sourcemap test - "raw-data" 1`] = `
   "nodeParts": {
     "1111-33": {
       "id": "main.js",
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 98,
+      "brotliLength": 83,
       "renderedLength": 84,
       "metaUid": "1111-32"
     },
     "1111-35": {
       "id": "virtual-id-7429d3ba.js",
-      "gzipLength": 0,
-      "brotliLength": 0,
+      "gzipLength": 87,
+      "brotliLength": 68,
       "renderedLength": 75,
       "metaUid": "1111-34"
     }
@@ -6709,8 +6713,8 @@ exports[`GH-93 sourcemap test - "raw-data" 1`] = `
     "rollup": "3.9.0"
   },
   "options": {
-    "gzip": false,
-    "brotli": false,
+    "gzip": true,
+    "brotli": true,
     "sourcemap": true
   }
 }"
@@ -13610,7 +13614,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","uid":"1111-25"},{"name":"virtual-id-7429d3ba.js","uid":"1111-27"}],"isRoot":true},"nodeParts":{"1111-25":{"id":"main.js","gzipLength":0,"brotliLength":0,"renderedLength":84,"metaUid":"1111-24"},"1111-27":{"id":"virtual-id-7429d3ba.js","gzipLength":0,"brotliLength":0,"renderedLength":75,"metaUid":"1111-26"}},"nodeMetas":{"1111-24":{"id":"/test/gh93/main.js","moduleParts":{"main.js":"1111-25"},"imported":[],"importedBy":[],"isEntry":true},"1111-26":{"id":"virtual-id","moduleParts":{"virtual-id-7429d3ba.js":"1111-27"},"imported":[],"importedBy":[],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","uid":"1111-25"},{"name":"virtual-id-7429d3ba.js","uid":"1111-27"}],"isRoot":true},"nodeParts":{"1111-25":{"id":"main.js","gzipLength":98,"brotliLength":83,"renderedLength":84,"metaUid":"1111-24"},"1111-27":{"id":"virtual-id-7429d3ba.js","gzipLength":87,"brotliLength":68,"renderedLength":75,"metaUid":"1111-26"}},"nodeMetas":{"1111-24":{"id":"/test/gh93/main.js","moduleParts":{"main.js":"1111-25"},"imported":[],"importedBy":[],"isEntry":true},"1111-26":{"id":"virtual-id","moduleParts":{"virtual-id-7429d3ba.js":"1111-27"},"imported":[],"importedBy":[],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":true,"brotli":true,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;
@@ -19791,7 +19795,7 @@ var drawChart = (function (exports) {
   </script>
   <script>
     /*<!--*/
-    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","uid":"1111-21"},{"name":"virtual-id-7429d3ba.js","uid":"1111-23"}],"isRoot":true},"nodeParts":{"1111-21":{"id":"main.js","gzipLength":0,"brotliLength":0,"renderedLength":84,"metaUid":"1111-20"},"1111-23":{"id":"virtual-id-7429d3ba.js","gzipLength":0,"brotliLength":0,"renderedLength":75,"metaUid":"1111-22"}},"nodeMetas":{"1111-20":{"id":"/test/gh93/main.js","moduleParts":{"main.js":"1111-21"},"imported":[],"importedBy":[],"isEntry":true},"1111-22":{"id":"virtual-id","moduleParts":{"virtual-id-7429d3ba.js":"1111-23"},"imported":[],"importedBy":[],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":false,"brotli":false,"sourcemap":true}};
+    const data = {"version":2,"tree":{"name":"root","children":[{"name":"main.js","uid":"1111-21"},{"name":"virtual-id-7429d3ba.js","uid":"1111-23"}],"isRoot":true},"nodeParts":{"1111-21":{"id":"main.js","gzipLength":98,"brotliLength":83,"renderedLength":84,"metaUid":"1111-20"},"1111-23":{"id":"virtual-id-7429d3ba.js","gzipLength":87,"brotliLength":68,"renderedLength":75,"metaUid":"1111-22"}},"nodeMetas":{"1111-20":{"id":"/test/gh93/main.js","moduleParts":{"main.js":"1111-21"},"imported":[],"importedBy":[],"isEntry":true},"1111-22":{"id":"virtual-id","moduleParts":{"virtual-id-7429d3ba.js":"1111-23"},"imported":[],"importedBy":[],"isEntry":true}},"env":{"rollup":"3.9.0"},"options":{"gzip":true,"brotli":true,"sourcemap":true}};
 
     const run = () => {
       const width = window.innerWidth;

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -1,4 +1,5 @@
 import { OutputAsset, OutputOptions, rollup } from "rollup";
+import terser from '@rollup/plugin-terser';
 import { describe, it, expect } from "@jest/globals";
 import { ALL_TEMPLATE } from "./util";
 
@@ -8,12 +9,12 @@ Math.random = () => randomCall / 100;
 
 import { visualizer } from "../dist/plugin";
 
-describe("E2E", () => {
-  const input = {
-    input: "./test/e2e/input.js",
-    input2: "./test/e2e/input2.js",
-  };
+const input = {
+  input: "./test/e2e/input.js",
+  input2: "./test/e2e/input2.js",
+};
 
+describe("E2E", () => {
   it.each(ALL_TEMPLATE)("test - %j", async (template) => {
     const inputOptions = {
       external: ["jquery"],
@@ -46,11 +47,6 @@ describe("E2E", () => {
 });
 
 describe("E2E sourcemap", () => {
-  const input = {
-    input: "./test/e2e/input.js",
-    input2: "./test/e2e/input2.js",
-  };
-
   it.each(ALL_TEMPLATE)("test - %j", async (template) => {
     const inputOptions = {
       external: ["jquery"],
@@ -59,6 +55,41 @@ describe("E2E sourcemap", () => {
         visualizer({
           filename: `stats`,
           template,
+          exclude: [{ file: "**/node_modules/**" }],
+          emitFile: true,
+          sourcemap: true,
+          brotliSize: true,
+          gzipSize: true,
+        }),
+      ],
+    };
+    const outputOptions: OutputOptions = {
+      format: "es",
+      dir: "./temp/",
+      sourcemap: true,
+    };
+
+    const bundle = await rollup(inputOptions);
+
+    const result = await bundle.generate(outputOptions);
+
+    const generatedStats = result.output.find((file) => file.fileName === "stats");
+
+    expect(generatedStats).not.toBe(null);
+    expect((generatedStats as OutputAsset).source).toMatchSnapshot();
+  });
+});
+
+describe("E2E sourcemap + terser", () => {
+  it("test", async () => {
+    const inputOptions = {
+      external: ["jquery"],
+      input,
+      plugins: [
+        terser(),
+        visualizer({
+          filename: `stats`,
+          template: 'raw-data',
           exclude: [{ file: "**/node_modules/**" }],
           emitFile: true,
           sourcemap: true,


### PR DESCRIPTION
Hi @btd! As discussed yesterday in #163, fixed sourcemap mode to correctly measure module size after minification. To address your concern about surrogate pairs, I collect actual `code` in the final chunk per-module instead of incrementing `renderedLength`.

Since we now have the precise code available in sourcemap mode, I also went ahead and allowed `gzipSize` and `brotliSize` in sourcemap mode. Compressed sizes are very close to ones in default mode.

Added a test case with terser, updated snapshots for both changes. Un-minified sourcemap sizes are 1 byte larger than `bundle.code[id]` because rollup trims trailing newline.

I wonder if we could remove non-sourcemap option altogether? It doesn't seem to have any benefits, and reports incorrect sizes.

Fixes #163 