### PR TITLE
Add rollup 4.x to peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "yargs": "^17.5.1"
   },
   "peerDependencies": {
-    "rollup": "2.x || 3.x"
+    "rollup": "2.x || 3.x || 4.x"
   },
   "peerDependenciesMeta": {
     "rollup": {


### PR DESCRIPTION
As far as I can tell, the plugin works fine with rollup 4.x, it just needs an updated peerDep value.

Fixes #172