### PR TITLE
Allow emitFile filenames that start with a period

### DIFF
--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -290,7 +290,9 @@ export const visualizer = (
       });
 
       if (opts.emitFile) {
-        if (path.isAbsolute(filename) || filename.startsWith("./") || filename.startsWith("../")) {
+        // Regex checks for filenames starting with `./`, `../`, `.\` or `..\`
+        // to account for windows-style path separators
+        if (path.isAbsolute(filename) ||  /^\.{1,2}[/\\]/.test(filename)) {
           this.error(ERR_FILENAME_EMIT);
         }
         this.emitFile({


### PR DESCRIPTION
The current check for "you can't have absolute or relative paths in the `filename` property" makes it impossible to create the filename `.vite/stats.html` even though that not a relative path and thus is a valid filename to pass into emitFile.

This PR updates the check so the relative path checks looks for files that start with `./` or `../` rather than any filename that starts with a `.`