### PR TITLE
Add `main` field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "author": "Denis Bardadym <bardadymchik@gmail.com>",
   "license": "MIT",
   "bin": "./dist/bin/cli.js",
+  "main": "./dist/plugin/index.js",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
While Node itself is happy with only an `exports` field in `package.json`, it doesn't seem enough for some tooling packages. The lack of `main` field:
- prevents TypeScript from resolving the types when used with the [`node` `moduleResolution`](https://www.typescriptlang.org/docs/handbook/modules/reference.html#node10-formerly-known-as-node)
- prevents [`eslint-plugin-import`](https://www.npmjs.com/package/eslint-plugin-import)'s module resolution through the `resolve` package, which [does not support ESM yet](https://github.com/browserify/resolve/issues/222).

There may also be other tools implementing their own module resolution which won't cope with having only `exports`. It'd be great if `rollup-plugin-visualizer` was offering a fallback `main` field in its package.json, as [described in Node's documentation](https://nodejs.org/api/packages.html#main-entry-point-export).