### PR TITLE
fix: rolldown support - stop importing from rollup in the published types

### DIFF
--- a/plugin/data.ts
+++ b/plugin/data.ts
@@ -1,4 +1,4 @@
-import { GetModuleInfo } from "rollup";
+import type { GetModuleInfo } from "./rollup-types.js";
 import { isModuleTree, ModuleLengths, ModuleTree, ModuleTreeLeaf } from "../shared/types.js";
 import { ModuleMapper } from "./module-mapper.js";
 

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -141,9 +141,6 @@ export const visualizer = (
       outputOptions: NormalizedOutputOptions,
       outputBundle: OutputBundle,
     ): Promise<void> {
-      // The local `OutputOptions` is a structural subset of rollup's
-      // `NormalizedOutputOptions` — see plugin/rollup-types.ts for why we
-      // don't import directly from "rollup" here.
       opts = typeof opts === "function" ? opts(outputOptions as unknown as OutputOptions) : opts;
 
       if ("json" in opts) {

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
-import { OutputBundle, Plugin, NormalizedOutputOptions, OutputOptions } from "rollup";
+import type { OutputBundle, NormalizedOutputOptions } from "rollup";
+import type { Plugin, OutputOptions } from "./rollup-types.js";
 import opn, { Options as OpenOptions } from "open";
 
 import { ModuleLengths, ModuleTree, ModuleTreeLeaf, VisualizerData } from "../shared/types.js";
@@ -140,7 +141,10 @@ export const visualizer = (
       outputOptions: NormalizedOutputOptions,
       outputBundle: OutputBundle,
     ): Promise<void> {
-      opts = typeof opts === "function" ? opts(outputOptions) : opts;
+      // The local `OutputOptions` is a structural subset of rollup's
+      // `NormalizedOutputOptions` — see plugin/rollup-types.ts for why we
+      // don't import directly from "rollup" here.
+      opts = typeof opts === "function" ? opts(outputOptions as unknown as OutputOptions) : opts;
 
       if ("json" in opts) {
         this.warn(WARN_JSON_DEPRECATED);

--- a/plugin/rollup-types.ts
+++ b/plugin/rollup-types.ts
@@ -41,7 +41,7 @@ export interface Plugin {
     options: any,
     bundle: any,
     isWrite?: boolean,
-  ) => unknown | Promise<unknown>;
+  ) => void | Promise<void>;
 }
 
 export interface OutputChunk {

--- a/plugin/rollup-types.ts
+++ b/plugin/rollup-types.ts
@@ -1,21 +1,5 @@
-/**
- * Local structural type stubs for rollup/rolldown.
- *
- * `rollup` and `rolldown` are declared as *optional* peer dependencies, so the
- * published `.d.ts` files cannot hard-import from either package — that would
- * force consumers using only one bundler to also install the other (~1 MB plus
- * native binaries) just to satisfy TypeScript.
- *
- * These minimal interfaces describe only what the visualizer plugin actually
- * exposes in its public API or consumes internally. They are intentionally
- * structural subsets of the corresponding `rollup` and `rolldown` types — both
- * of which export `Plugin`, `OutputOptions`, `OutputChunk`, and
- * `GetModuleInfo` with compatible shapes — so the plugin object the visualizer
- * returns is assignable to either bundler's `plugins` array.
- *
- * If you need richer typing for output options inside an options factory or
- * for a particular hook, cast to the relevant bundler's type in your own code.
- */
+// Structural stubs for rollup/rolldown types. Both bundlers are optional peer
+// deps, so the published .d.ts files can't hard-import from either.
 
 export interface OutputOptions {
   dir?: string;

--- a/plugin/rollup-types.ts
+++ b/plugin/rollup-types.ts
@@ -1,0 +1,60 @@
+/**
+ * Local structural type stubs for rollup/rolldown.
+ *
+ * `rollup` and `rolldown` are declared as *optional* peer dependencies, so the
+ * published `.d.ts` files cannot hard-import from either package — that would
+ * force consumers using only one bundler to also install the other (~1 MB plus
+ * native binaries) just to satisfy TypeScript.
+ *
+ * These minimal interfaces describe only what the visualizer plugin actually
+ * exposes in its public API or consumes internally. They are intentionally
+ * structural subsets of the corresponding `rollup` and `rolldown` types — both
+ * of which export `Plugin`, `OutputOptions`, `OutputChunk`, and
+ * `GetModuleInfo` with compatible shapes — so the plugin object the visualizer
+ * returns is assignable to either bundler's `plugins` array.
+ *
+ * If you need richer typing for output options inside an options factory or
+ * for a particular hook, cast to the relevant bundler's type in your own code.
+ */
+
+export interface OutputOptions {
+  dir?: string;
+  file?: string;
+  format?: string;
+  name?: string;
+  entryFileNames?: string | ((chunkInfo: any) => string);
+  chunkFileNames?: string | ((chunkInfo: any) => string);
+  assetFileNames?: string | ((assetInfo: any) => string);
+  sourcemap?: boolean | "inline" | "hidden";
+  banner?: unknown;
+  footer?: unknown;
+  intro?: unknown;
+  outro?: unknown;
+  globals?: unknown;
+  exports?: "auto" | "default" | "named" | "none";
+}
+
+export interface Plugin {
+  name: string;
+  generateBundle?: (
+    this: any,
+    options: any,
+    bundle: any,
+    isWrite?: boolean,
+  ) => unknown | Promise<unknown>;
+}
+
+export interface OutputChunk {
+  type: "chunk";
+  code: string;
+  map?: unknown;
+  facadeModuleId?: string | null;
+  modules: Record<string, { renderedLength: number; code: string | null }>;
+}
+
+export type GetModuleInfo = (moduleId: string) => {
+  isEntry: boolean;
+  isExternal: boolean;
+  importedIds: readonly string[];
+  dynamicallyImportedIds?: readonly string[];
+} | null;

--- a/plugin/sourcemap.ts
+++ b/plugin/sourcemap.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { OutputChunk } from "rollup";
+import type { OutputChunk } from "./rollup-types.js";
 import type { RawSourceMap } from "source-map";
 import { SourceMapConsumer } from "source-map";
 


### PR DESCRIPTION
closes #219

## Fix

Replaces hard imports of `Plugin`, `OutputOptions`, `OutputChunk`, and `GetModuleInfo` from `"rollup"` in `plugin/{index,sourcemap,data}.ts` with structural stubs in a new `plugin/rollup-types.ts`. The stubs are subsets of both `rollup`'s and `rolldown`'s types, so `visualizer()`'s return value still drops cleanly into either bundler's `plugins` array.

`generateBundle` is typed `=> void | Promise<void>` (rollup's signature; also accepted by rolldown's stricter `=> void`). Internal types (`OutputBundle`, `NormalizedOutputOptions`) keep their `import type` from `"rollup"` since they don't leak into the emitted `.d.ts`.

## Test plan

| Scenario | Before | After |
|---|---|---|
| rolldown only, no rollup | ❌ TS2307 | ✅ `tsc --noEmit` exits 0 |
| rollup only, no rolldown | ✅ exits 0 | ✅ exits 0 (no regression) |
| both installed | ✅ exits 0 | ✅ exits 0 |
| `npm test` | ✅ unchanged | ✅ 125/125 pass |
| `npm run lint` | ✅ unchanged | ✅ clean |
| `grep 'from "rollup"' dist/` | ❌ hits in `.d.ts` | ✅ none |
