### PR TITLE
fix repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:btd/rollup-plugin-visualizer.git"
+    "url": "https://github.com/btd/rollup-plugin-visualizer.git"
   },
   "homepage": "https://github.com/btd/rollup-plugin-visualizer",
   "bugs": {


### PR DESCRIPTION
## Summary

- update the package repository URL from the SSH shorthand to the public HTTPS GitHub URL

## Validation

- checked `package.json` parses and points to `https://github.com/btd/rollup-plugin-visualizer.git`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`
